### PR TITLE
parser.py: add serverEndpoint as optional param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.log
 /.settings/
 /tika/*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 tika-python
 ===========
 A Python port of the [Apache Tika](http://tika.apache.org/)
-library that makes Tika available using the 
+library that makes Tika available using the
 [Tika REST Server](http://wiki.apache.org/tika/TikaJAXRS).
 
-This makes Apahce Tika available as a Python 
+This makes Apahce Tika available as a Python
 library, installable via Setuptools, Pip and Easy Install.
 
 Inspired by [Aptivate Tika](https://github.com/aptivate/python-tika).
@@ -38,6 +38,11 @@ from tika import parser
 parsed = parser.from_file('/path/to/file')
 print parsed["metadata"]
 print parsed["content"]
+
+# Optionally, you can pass Tika server URL along with the call
+# what's useful for multi-instance execution or when Tika is dockerzed/linked
+parsed = parser.from_file('/path/to/file', 'http://tika:9998/tika')
+string_parsed = parser.from_buffer('Good evening, Dave', 'http://tika:9998/tika')
 ```
 
 Detect Interface (new)
@@ -73,7 +78,7 @@ Using a Buffer
 Note you can also use a Parser and Detector
 .from_buffer(string) method to dynamically parser
 a string buffer in Python and/or detect its MIME
-type. This is useful if you've already loaded 
+type. This is useful if you've already loaded
 the content into memory.
 
 New Command Line Client Tool
@@ -112,7 +117,7 @@ Commands:
 
 Arguments:
   urlOrPathToFile = file to be parsed, if URL it will first be retrieved and then passed to Tika
-  
+
 Switches:
   --verbose, -v                  = verbose mode
   --server <TikaServerEndpoint>  = use a remote Tika Server at this endpoint, otherwise use local server

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # $Id$
 
 import os.path
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 
-version = '1.8.5'
+version = '1.8.6'
 
 _descr = u'''**********
 tika
@@ -58,7 +58,7 @@ _classifiers = [
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-long_description = _descr 
+long_description = _descr
 
 setup(
     name='tika',
@@ -81,7 +81,7 @@ setup(
         'console_scripts': [
             'tika-python = tika.tika:main'
         ],
-    }, 
+    },
     package_data = {
         # And include any *.conf files found in the 'conf' subdirectory
         # for the package
@@ -89,7 +89,7 @@ setup(
     install_requires=[
         'setuptools',
         'requests'
-    ], 
+    ],
     extras_require={
     },
 )

--- a/tika/parser.py
+++ b/tika/parser.py
@@ -14,18 +14,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 
 from tika import parse1, callServer, ServerEndpoint
 import os
 import json
 
-def from_file(filename):
-    jsonOutput = parse1('all', filename)
+def from_file(filename, serverEndpoint=ServerEndpoint):
+    jsonOutput = parse1('all', filename, serverEndpoint)
     return _parse(jsonOutput)
 
-def from_buffer(string):
-    status, response = callServer('put', ServerEndpoint, '/rmeta', string,
+def from_buffer(string, serverEndpoint=ServerEndpoint):
+    status, response = callServer('put', serverEndpoint, '/rmeta', string,
             {'Accept': 'application/json'}, False)
     return _parse((status,response))
 
@@ -39,7 +39,7 @@ def _parse(jsonOutput):
     for js in realJson:
         if "X-TIKA:content" in js:
             content += js["X-TIKA:content"]
-    
+
     if content == "":
         content = None
 


### PR DESCRIPTION
When running Tika in a Docker linked container (for example, within `docker-compose` linking), it's important to have an ability to pass Tika's container URL along with a programatically invocation. Also it's useful when running Tika on multiple instances.

Now it's possible with optional:

```python
parsed = parser.from_file('/path/to/file', 'http://tika:9998/tika')
string_parsed = parser.from_buffer('Good evening, Dave', 'http://tika:9998/tika')
```

README updated, version bumped, minor styling fixes (EOL, trailing spaces)