### PR TITLE
Remove extra list nesting in metadata hash map

### DIFF
--- a/tika/parser.py
+++ b/tika/parser.py
@@ -52,6 +52,6 @@ def _parse(jsonOutput):
                 if n in parsed["metadata"]:
                     parsed["metadata"][n].append(js[n])
                 else:
-                    parsed["metadata"][n] = [js[n]]
+                    parsed["metadata"][n] = js[n]
 
     return parsed


### PR DESCRIPTION
Hey Chris,

Currently the metadata object gathered from parsing a document has an extra nest of lists for every key.

Shortened Example:
```
{
  u'access_permission:can_modify': [u'true'], 
  u'access_permission:extract_content': [u'true'],  
  u'X-Parsed-By': [[u'org.apache.tika.parser.DefaultParser', u'org.apache.tika.parser.pdf.PDFParser']]
}
```

This deviates from the result that you get when you call Tika from the command line:

```
{
  "access_permission:can_modify":"true",
  "access_permission:extract_content":"true",
  "X-Parsed-By":["org.apache.tika.parser.DefaultParser","org.apache.tika.parser.pdf.PDFParser"]
}
```

Not sure if that nesting is there for a reason, so feel free to ignore if so.