### PR TITLE
Modified --server reference to serverHost

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -390,12 +390,13 @@ def main(argv=None):
         
     tikaServerJar = TikaServerJar
     serverEndpoint = ServerEndpoint
+    serverHost = ServerHost
     outDir = '.'
     port = Port
     for opt, val in opts:
         if opt   in ('-h', '--help'):    echo2(USAGE); sys.exit()
         elif opt in ('--install'):       tikaServerJar = val
-        elif opt in ('--server'):        serverEndpoint = val
+        elif opt in ('--server'):        serverHost = val
         elif opt in ('-o', '--output'):  outDir = val
         elif opt in ('--port'):          port = val
         elif opt in ('-v', '--verbose'): Verbose = 1
@@ -407,7 +408,7 @@ def main(argv=None):
         paths = argv[2:]
     except:
         paths = None
-    return runCommand(cmd, option, paths, port, outDir, serverHost=ServerHost, tikaServerJar=tikaServerJar, verbose=Verbose)
+    return runCommand(cmd, option, paths, port, outDir, serverHost=serverHost, tikaServerJar=tikaServerJar, verbose=Verbose)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently ```--server``` points to ServerEndPoint which is not passed to the ```runCommand``` method and thus lead us nowhere. 

Hence, modified ```--server``` reference to ```serverHost``` and passed it to the ```runCommand``` method. For eg: To parse image data using Tika Server, we can use the below command:

```tika.py --server localhost --port 9990 parse all /tmp/xyz.jpg```