### PR TITLE
Added switch that reports type detect results in CSV format  (including file names/paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Arguments:
 
 Switches:
   --verbose, -v                  = verbose mode
+  --encode, -e           = encode response in UTF-8
+  --csv, -c    = report detect output in comma-delimited format
   --server <TikaServerEndpoint>  = use a remote Tika Server at this endpoint, otherwise use local server
   --install <UrlToTikaServerJar> = download and exec Tika Server (JAR file), starting server on default port 9998
 

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -478,4 +478,5 @@ if __name__ == '__main__':
         out.write('\n'.join([r[1] for r in resp]))
     else:
         out.write(resp)
+    out.write('\n')
 

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -458,7 +458,17 @@ def main(argv=None):
 
 if __name__ == '__main__':
     resp = main(sys.argv)
+
+    # Set encoding of the terminal to UTF-8
+    if sys.version.startswith("2"):
+        # Python 2.x
+        out = codecs.getwriter("UTF-8")(sys.stdout)
+    elif sys.version.startswith("3"):
+        # Python 3.x
+        out = codecs.getwriter("UTF-8")(sys.stdout.buffer)
+
     if type(resp) == list:
-        print('\n'.join([r[1] for r in resp]))
+        out.write('\n'.join([r[1] for r in resp]))
     else:
-        print(resp)
+        out.write(resp)
+


### PR DESCRIPTION
When running the detector from the CLI, it only outputs the detection results, e.g.:

```
image/jp2
image/jp2
image/jp2
image/jp2
```

This is consistent with the CLI of the Java version, but it is not very helpful when you're e.g. processing all files in a directory (because it makes it impossible to track to what file each result corresponds). 

This  patch adds a `-c` / `--csv` option, which allows one to report the detection results as a comma-separated list that includes the name (or full path, depending on how the tool is called). Here's an example:

    python tika.py -c detect type ~/jpylyzer-test-files/*

Result:

```
/home/johan/jpylyzer-test-files/reference.jp2,image/jp2
/home/johan/jpylyzer-test-files/truncated_at_byte_5000.jp2,image/jp2
/home/johan/jpylyzer-test-files/ランダム日本語テキスト.jp2,image/jp2
/home/johan/jpylyzer-test-files/隨機中國文字.jp2,image/jp2
```

In order to make this work both in a terminal window as well as when redirected to a file, I changed to  *codecs.getwriter* for writing the output (using a UTF-8 encoding). I also fixed a minor issue with a missing newline. 