### PR TITLE
add versioning to tika-python library

### DIFF
--- a/tika/__init__.py
+++ b/tika/__init__.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__version__ = "1.13.1"
+
 try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:


### PR DESCRIPTION
@chrismattmann 

This trivial PR adds __version__ to __init__.py typical to most python libraries **[0]** 

```
>>> import tika
>>> 
>>> tika.__version__
'1.13.1'
```

The **version** variable found in **setup.py** is to fetch the latest tika-server.jar from Maven Central, while building tika-python.

[0] http://stackoverflow.com/a/20180564/5061477