### PR TITLE
Unpack interface to use /unpack/all

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -94,7 +94,7 @@ log_path = tempfile.gettempdir()
 log_file = os.path.join(log_path, 'tika.log')
 
 logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
-log = logging.getLogger()
+log = logging.getLogger('tika.tika')
 
 # File logs
 fileHandler = logging.FileHandler(log_file)

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -205,7 +205,7 @@ def parse(option, urlOrPaths, serverEndpoint=ServerEndpoint, verbose=Verbose, ti
 
 def parse1(option, urlOrPath, serverEndpoint=ServerEndpoint, verbose=Verbose, tikaServerJar=TikaServerJar, 
           responseMimeType='application/json',
-          services={'meta': '/meta', 'text': '/tika', 'all': '/rmeta/text'}):
+          services={'meta': '/meta', 'text': '/tika', 'all': '/rmeta/text'}, rawResponse=False):
     """Parse the object and return extracted metadata and/or text in JSON format."""
     path, file_type = getRemoteFile(urlOrPath, TikaFilesPath)
     if option not in services:
@@ -214,7 +214,7 @@ def parse1(option, urlOrPath, serverEndpoint=ServerEndpoint, verbose=Verbose, ti
     if service == '/tika': responseMimeType = 'text/plain'
     status, response = callServer('put', serverEndpoint, service, open(path, 'rb'),
                                   {'Accept': responseMimeType, 'Content-Disposition': 'attachment; filename=%s' % os.path.basename(path)}, 
-                                  verbose, tikaServerJar)
+                                  verbose, tikaServerJar, rawResponse=rawResponse)
     
     if file_type == 'remote': os.unlink(path)
     return (status, response)
@@ -310,7 +310,8 @@ def getConfig(option, serverEndpoint=ServerEndpoint, verbose=Verbose, tikaServer
 
 
 def callServer(verb, serverEndpoint, service, data, headers, verbose=Verbose, tikaServerJar=TikaServerJar, 
-               httpVerbs={'get': requests.get, 'put': requests.put, 'post': requests.post},classpath=None):
+               httpVerbs={'get': requests.get, 'put': requests.put, 'post': requests.post}, classpath=None,
+               rawResponse=False):
     """Call the Tika Server, do some error checking, and return the response."""
     
     parsedUrl = urlparse(serverEndpoint) 
@@ -340,9 +341,12 @@ def callServer(verb, serverEndpoint, service, data, headers, verbose=Verbose, ti
         print(sys.stderr, "Request headers: ", headers)
         print(sys.stderr, "Response headers: ", resp.headers)
     if resp.status_code != 200:
-        log.warning('Tika server returned status:', resp.status_code)
+        log.warning('Tika server returned status: %d' % resp.status_code)
     resp.encoding = "utf-8"
-    return (resp.status_code, resp.text)
+    if rawResponse:
+        return (resp.status_code, resp.content)
+    else:
+        return (resp.status_code, resp.text)
 
 
 def checkTikaServer(serverHost=ServerHost, port = Port, tikaServerJar=TikaServerJar,classpath=None):

--- a/tika/unpack.py
+++ b/tika/unpack.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .tika import parse1, callServer, ServerEndpoint
+import os
+import tarfile
+from io import BytesIO, TextIOWrapper
+import csv
+
+def from_file(filename, serverEndpoint=ServerEndpoint):
+    tarOutput = parse1('unpack', filename, serverEndpoint,
+                       responseMimeType='application/x-tar', 
+                       services={'meta': '/meta', 'text': '/tika',
+                                 'all': '/rmeta/xml', 'unpack': '/unpack/all'},
+                       rawResponse=True)
+    return _parse(tarOutput)
+
+
+def from_buffer(string, serverEndpoint=ServerEndpoint):
+    status, response = callServer('put', serverEndpoint, '/unpack/all', string,
+                                  {'Accept': 'application/x-tar'}, False,
+                                  rawResponse=True)      
+  
+    return _parse((status, response))
+
+
+def _parse(tarOutput):
+    parsed = {}
+    if not tarOutput:
+        return parsed
+    elif tarOutput[1] is None or tarOutput[1] == b"":
+        return parsed
+
+    tarFile = tarfile.open(fileobj=BytesIO(tarOutput[1]))
+
+    # get the member names
+    memberNames = list(tarFile.getnames())
+
+    # extract the metadata
+    metadata = {}
+    if "__METADATA__" in memberNames:
+        memberNames.remove("__METADATA__")
+
+        metadataMember = tarFile.getmember("__METADATA__")
+        if not metadataMember.issym() and metadataMember.isfile():
+            metadataFile = TextIOWrapper(tarFile.extractfile(metadataMember))
+            metadataReader = csv.reader(metadataFile)
+            for metadataLine in metadataReader:
+                # each metadata line comes as a key-value pair, with list values
+                # returned as extra values in the line - convert single values
+                # to non-list values to be consistent with parser metadata
+                assert len(metadataLine) >= 2
+
+                if len(metadataLine) > 2:
+                    metadata[metadataLine[0]] = metadataLine[1:]
+                else:
+                    metadata[metadataLine[0]] = metadataLine[1]
+
+    # get the content
+    content = ""
+    if "__TEXT__" in memberNames:
+        memberNames.remove("__TEXT__")
+
+        contentMember = tarFile.getmember("__TEXT__")
+        if not contentMember.issym() and contentMember.isfile():
+            content = TextIOWrapper(tarFile.extractfile(contentMember)).read()
+
+    # get the remaining files as attachments
+    attachments = {}
+    for attachment in memberNames:
+        attachmentMember = tarFile.getmember(attachment)
+        if not attachmentMember.issym() and attachmentMember.isfile():
+            attachments[attachment] = tarFile.extractfile(attachmentMember).read()
+
+    parsed["content"] = content
+    parsed["metadata"] = metadata
+    parsed["attachments"] = attachments
+
+    return parsed


### PR DESCRIPTION
Add the ability to hit the Tika _/unpack/all_ interface which allows extracting metadata, text and attachments from one analysis run. Details are extracted in a dictionary as is done in _parser_.

Also change from using the root logger name to using _tika.tika_ to assist integration with other libraries.
