### PR TITLE
Read the log file path from TIKA_LOG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 4. `TIKA_CLIENT_ONLY` - if set to True, then `TIKA_SERVER_JAR` is ignored, and relies on the value for `TIKA_SERVER_ENDPOINT` and treats Tika like a REST client.
 5. `TIKA_TRANSLATOR` - set to the fully qualified class name (defaults to Lingo24) for the Tika translator implementation.
 6. `TIKA_SERVER_CLASSPATH` - set to a string (delimited by ':' for each additional path) to prepend to the Tika server jar path.
+7. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
 
 Testing it out
 ==============

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -98,7 +98,7 @@ from subprocess import STDOUT
 from os import walk
 import logging
 
-log_path = tempfile.gettempdir()
+log_path = os.getenv('TIKA_LOG_PATH', tempfile.gettempdir())
 log_file = os.path.join(log_path, 'tika.log')
 
 logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
@@ -121,7 +121,7 @@ Windows = True if platform.system() == "Windows" else False
 TikaVersion = os.getenv('TIKA_VERSION', '1.14')
 TikaJarPath = tempfile.gettempdir()
 TikaFilesPath = tempfile.gettempdir()
-TikaServerLogFilePath = tempfile.gettempdir()
+TikaServerLogFilePath = log_path
 TikaServerJar = os.getenv(
     'TIKA_SERVER_JAR',
     "http://search.maven.org/remotecontent?filepath=org/apache/tika/tika-server/"+TikaVersion+"/tika-server-"+TikaVersion+".jar")


### PR DESCRIPTION
Without this patch, multiple instances of tika-python in client mode run by different unix users required write access to the same `/tmp/tika.log` file, which caused an error on import.

With this patch, the path for both the `tika-server.log` file and `tika.log` file is configurable through the `TIKA_LOG_PATH` environment variable.

This should close #133.