### PR TITLE
Add TIKA_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 5. `TIKA_TRANSLATOR` - set to the fully qualified class name (defaults to Lingo24) for the Tika translator implementation.
 6. `TIKA_SERVER_CLASSPATH` - set to a string (delimited by ':' for each additional path) to prepend to the Tika server jar path.
 7. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
+8. `TIKA_PATH` - set to a directory with write permissions and the `tika_server.jar` file will be placed in this directory.
 
 Testing it out
 ==============

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -153,7 +153,7 @@ log.setLevel(logging.INFO)
 
 Windows = True if platform.system() == "Windows" else False
 TikaVersion = os.getenv('TIKA_VERSION', '1.15')
-TikaJarPath = tempfile.gettempdir()
+TikaJarPath = os.getenv('TIKA_PATH', tempfile.gettempdir())
 TikaFilesPath = tempfile.gettempdir()
 TikaServerLogFilePath = log_path
 TikaServerJar = os.getenv(


### PR DESCRIPTION
I added this environment variable because I was having issues with the default save location for the Tika jar (/tmp). After restarting the computer, the file ofcourse disappears and there is a bug where this library tries to read `TikaJarPath` without properly checking if the file exists and throws an error which breaks my system. This happens inside `checkJarSig()` (I know this check is done before calling the function but it is compromised by the check for `urlp.scheme != ''`).

Rather than fixing this issue and introducing more bugs (since I did not have time to study the signficance of `urlp.scheme`), I just felt it is totally logical to have an environment variable to enable me to specify where the jar and md5 files are downloaded to (I want them in my application root directory) and also to ensure the download does not need to happen after every restart (my application runs offline).

I am already using my solution and I love it so far.
