### PR TITLE
PR re: issue #113

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 6. `TIKA_SERVER_CLASSPATH` - set to a string (delimited by ':' for each additional path) to prepend to the Tika server jar path.
 7. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
 8. `TIKA_PATH` - set to a directory with write permissions and the `tika_server.jar` file will be placed in this directory.
+9. `TIKA_JAVA` - set the Java runtime name, e.g., `java` or `java9`
+10. `TIKA_STARTUP_SLEEP` - number of seconds to wait per check if Tika server is launched at runtime
+11. `TIKA_STARTUP_MAX_RETRY` - number of checks to attempt for Tika server startup if launched at runtime
 
 Testing it out
 ==============

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 7. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
 8. `TIKA_PATH` - set to a directory with write permissions and the `tika_server.jar` file will be placed in this directory.
 9. `TIKA_JAVA` - set the Java runtime name, e.g., `java` or `java9`
-10. `TIKA_STARTUP_SLEEP` - number of seconds to wait per check if Tika server is launched at runtime
-11. `TIKA_STARTUP_MAX_RETRY` - number of checks to attempt for Tika server startup if launched at runtime
+10. `TIKA_STARTUP_SLEEP` - number of seconds (`float`) to wait per check if Tika server is launched at runtime
+11. `TIKA_STARTUP_MAX_RETRY` - number of checks (`int`) to attempt for Tika server startup if launched at runtime
 
 Testing it out
 ==============

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -168,8 +168,8 @@ Translator = os.getenv(
     "org.apache.tika.language.translate.Lingo24Translator")
 TikaClientOnly = os.getenv('TIKA_CLIENT_ONLY', False)
 TikaServerClasspath = os.getenv('TIKA_SERVER_CLASSPATH', '')
-TikaStartupSleep = os.getenv('TIKA_STARTUP_SLEEP', 5)
-TikaStartupMaxRetry = os.getenv('TIKA_STARTUP_MAX_RETRY', 3)
+TikaStartupSleep = float(os.getenv('TIKA_STARTUP_SLEEP', 5))
+TikaStartupMaxRetry = int(os.getenv('TIKA_STARTUP_MAX_RETRY', 3))
 TikaJava = os.getenv("TIKA_JAVA", "java")
 
 Verbose = 0
@@ -640,11 +640,13 @@ def startServer(tikaServerJar, java_path = TikaJava, serverHost = ServerHost, po
             # check for INFO string to confirm listening endpoint
             if "Started Apache Tika server at" in tika_log_file_tmp.read():
                 is_started = True
+            else:
+                log.warning("Failed to see startup log message; retrying...")
         time.sleep(TikaStartupSleep)
         try_count += 1
 
     if not is_started:
-        log.error("Tika startup log message not received after %d tries" % (TikaStartupMaxRetry))
+        log.error("Tika startup log message not received after %d tries." % (TikaStartupMaxRetry))
         return False
     else:
         return True


### PR DESCRIPTION
As discussed in #113:

* Added `TIKA_JAVA` to env vars to support alternative javas
* Added `TIKA_STARTUP_SLEEP` to env vars to support customization of sleep
* Added `TIKA_STARTUP_MAX_RETRY` to env vars to support customization of retry/checks and avoid potential inf loop
* Add return status to `startServer` and check; throw `RuntimError` if failed
* Add error logs with description of issue
* Documented env vars in `README.md`