### PR TITLE
updated to v1.19 and added custom config option

### DIFF
--- a/tika/detector.py
+++ b/tika/detector.py
@@ -18,21 +18,21 @@
 
 from .tika import detectType1, callServer, ServerEndpoint
 
-def from_file(filename):
+def from_file(filename, config_path=None):
     '''
     Detects MIME type of specified file
     :param filename: file whose type needs to be detected
     :return: MIME type
     '''
-    jsonOutput = detectType1('type', filename)
+    jsonOutput = detectType1('type', filename, config_path=config_path)
     return jsonOutput[1]
 
-def from_buffer(string):
+def from_buffer(string, config_path=None):
     '''
     Detects MIME type of the buffered content
     :param string: buffered content whose type needs to be detected
     :return:
     '''
     status, response = callServer('put', ServerEndpoint, '/detect/stream', string,
-                                  {'Accept': 'text/plain'}, False)
+                                  {'Accept': 'text/plain'}, False, config_path=config_path)
     return response

--- a/tika/parser.py
+++ b/tika/parser.py
@@ -20,7 +20,7 @@ from .tika import parse1, callServer, ServerEndpoint
 import os
 import json
 
-def from_file(filename, serverEndpoint=ServerEndpoint, xmlContent=False, headers=None):
+def from_file(filename, serverEndpoint=ServerEndpoint, xmlContent=False, headers=None, config_path=None):
     '''
     Parses a file for metadata and content
     :param filename: path to file which needs to be parsed
@@ -33,13 +33,14 @@ def from_file(filename, serverEndpoint=ServerEndpoint, xmlContent=False, headers
             'content' has a str value and metadata has a dict type value.
     '''
     if not xmlContent:
-        jsonOutput = parse1('all', filename, serverEndpoint, headers=headers)
+        jsonOutput = parse1('all', filename, serverEndpoint, headers=headers, config_path=config_path)
     else:
-        jsonOutput = parse1('all', filename, serverEndpoint, services={'meta': '/meta', 'text': '/tika', 'all': '/rmeta/xml'}, headers=headers)
+        jsonOutput = parse1('all', filename, serverEndpoint, services={'meta': '/meta', 'text': '/tika', 'all': '/rmeta/xml'},
+                            headers=headers, config_path=config_path)
     return _parse(jsonOutput)
 
 
-def from_buffer(string, serverEndpoint=ServerEndpoint, xmlContent=False, headers=None):
+def from_buffer(string, serverEndpoint=ServerEndpoint, xmlContent=False, headers=None, config_path=None):
     '''
     Parses the content from buffer
     :param string: Buffer value
@@ -54,9 +55,9 @@ def from_buffer(string, serverEndpoint=ServerEndpoint, xmlContent=False, headers
     headers.update({'Accept': 'application/json'})
 
     if not xmlContent:
-        status, response = callServer('put', serverEndpoint, '/rmeta/text', string, headers, False)
+        status, response = callServer('put', serverEndpoint, '/rmeta/text', string, headers, False, config_path=config_path)
     else:
-        status, response = callServer('put', serverEndpoint, '/rmeta/xml', string, headers, False)
+        status, response = callServer('put', serverEndpoint, '/rmeta/xml', string, headers, False, config_path=config_path)
 
     return _parse((status,response))
 


### PR DESCRIPTION
I updated the tika server to version 1.19 and added options to the parsers and detectors to pass a custom configuration file. The default for the configuration file is None, so it should be backwards compatible. The changes have passed the tests in test_tika.py. 