### PR TITLE
standalone test to check ssl issue

### DIFF
--- a/tika/tests/test_ssl_link.py
+++ b/tika/tests/test_ssl_link.py
@@ -1,0 +1,36 @@
+# coding=utf8
+
+import unittest
+import tempfile
+import os 
+import shutil
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
+class CreateTest(unittest.TestCase):
+    """This is standalone test for the ssl link below, to verify it this is 
+        to the environemnt of the any commit
+    """
+    def setUp(self):
+        self.folder = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.folder):
+            shutil.rmtree(self.folder)
+
+    def test_url(self):
+        url = 'https://www.nasa.gov/sites/default/files/thumbnails/image/j2m-shareable.jpg'
+        path = os.path.join(self.folder, "pic.jpg")    
+        urlretrieve(url, path)
+        self.assertTrue(os.path.exists(path)) 
+        stat = os.stat(path)
+        self.assertGreater(stat.st_size, 10000)
+
+if __name__ == '__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
@chrismattmann I've added test to check the url https://www.nasa.gov/sites/default/files/thumbnails/image/j2m-shareable.jpg on python 2.6. The test just uses the urlretrieve and does not use any pytika code.
As you can see, the test fails on 2.6. 