### PR TITLE
New configuration property TIKA_JAVA_ARGS to adjust JVM options for Tika

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 9. `TIKA_JAVA` - set the Java runtime name, e.g., `java` or `java9`
 10. `TIKA_STARTUP_SLEEP` - number of seconds (`float`) to wait per check if Tika server is launched at runtime
 11. `TIKA_STARTUP_MAX_RETRY` - number of checks (`int`) to attempt for Tika server startup if launched at runtime
-
+12. `TIKA_JAVA_ARGS` - set java runtime arguments, e.g, `-Xmx4g`
 Testing it out
 ==============
 

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -180,6 +180,7 @@ TikaServerClasspath = os.getenv('TIKA_SERVER_CLASSPATH', '')
 TikaStartupSleep = float(os.getenv('TIKA_STARTUP_SLEEP', 5))
 TikaStartupMaxRetry = int(os.getenv('TIKA_STARTUP_MAX_RETRY', 3))
 TikaJava = os.getenv("TIKA_JAVA", "java")
+TikaJavaArgs = os.getenv("TIKA_JAVA_ARGS", '')
 
 Verbose = 0
 EncodeUtf8 = 0
@@ -578,7 +579,7 @@ def checkTikaServer(scheme="http", serverHost=ServerHost, port=Port, tikaServerJ
                 os.remove(jarPath)
                 tikaServerJar = getRemoteJar(tikaServerJar, jarPath)
 
-            status = startServer(jarPath, TikaJava, serverHost, port, classpath, config_path)
+            status = startServer(jarPath, TikaJava, TikaJavaArgs, serverHost, port, classpath, config_path)
             if not status:
                 log.error("Failed to receive startup confirmation from startServer.")
                 raise RuntimeError("Unable to start Tika server.")
@@ -602,7 +603,7 @@ def checkJarSig(tikaServerJar, jarPath):
             return existingContents == m.hexdigest()
 
 
-def startServer(tikaServerJar, java_path = TikaJava, serverHost = ServerHost, port = Port, classpath=None, config_path=None):
+def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, serverHost = ServerHost, port = Port, classpath=None, config_path=None):
     '''
     Starts Tika Server
     :param tikaServerJar: path to tika server jar
@@ -626,11 +627,11 @@ def startServer(tikaServerJar, java_path = TikaJava, serverHost = ServerHost, po
     # setup command string
     cmd_string = ""
     if not config_path:
-        cmd_string = '%s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s &' \
-                     % (java_path, classpath, port, host)
+        cmd_string = '%s %s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s &' \
+                     % (java_path, java_args, classpath, port, host)
     else:
-        cmd_string = '%s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
-                     % (java_path, classpath, port, host, config_path)
+        cmd_string = '%s %s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
+                     % (java_path, java_args, classpath, port, host, config_path)
 
     # Check that we can write to log path
     try:


### PR DESCRIPTION
Hi, I open new PR, as it almost impossible to get rid of auto-format issues in previous. 
This PR adds a new environmental variable to control JVM options when starting Tika server