### PR TITLE
Add binary stream functionality to parser.py from_file

### DIFF
--- a/tika/parser.py
+++ b/tika/parser.py
@@ -23,7 +23,7 @@ import json
 def from_file(filename, serverEndpoint=ServerEndpoint, xmlContent=False, headers=None, config_path=None):
     '''
     Parses a file for metadata and content
-    :param filename: path to file which needs to be parsed
+    :param filename: path to file which needs to be parsed or binary file using open(path,'rb')
     :param serverEndpoint: Server endpoint url
     :param xmlContent: Whether or not XML content be requested.
                     Default is 'False', which results in text content.

--- a/tika/tests/files/rwservlet.pdf
+++ b/tika/tests/files/rwservlet.pdf
@@ -1,0 +1,802 @@
+%PDF-1.4
+1 0 obj
+<<
+/Creator (Oracle11gR1 AS Reports Services)
+/CreationDate (D:20191125122421)
+/ModDate (D:20191125122421)
+/Producer (Oracle PDF driver)
+/Title ()
+/Author (Oracle Reports)
+>>
+endobj
+5 0 obj
+<</Length 6 0 R
+/Filter [/ASCII85Decode /FlateDecode]
+>>
+stream
+Gat=0gN))Z&UekgrrKP)U25+p"RkA0XgF+ZfXm$;oi@6u"/V\:AnQj.P2f3L4oitQRj8J6j)UDr
+X.'?R7cSTcH1?QsoHV[\5LeS^W#hNpqt]CM1[2qQp"q$PQUr`G/tY@Tq:ZK;eA&Z,J,\g$I'^p:
+*qS2HED[d#br>/>cSj%C\BO\MeSOh_o+uE<hri=5\QT3B=NIk_;urQ'0$CZ4cL,areTkH`Ffj2J
+d8/b5RO\!ONdLIChj5(OrM!!_,Z:VHoH3\.TX?XPdq+o(]<-<\Co+Wm`BTqYo9Q)A(<n=lJ_'I)
+5:J%Wf1jE^AE8G"p=)koi$&U-G-K8<ht)4KncK&b=<10JgoF[r$9b()NAup)2"<U3GRg@\I-kuB
+Js@_&<PI4Eo?[4?E_S&jaEFe2S?&AulJ"]!nG#=TSI6>2IQ15bHr>ADGPNa$8q.F!kp#f;:qY)f
+ZJW`ga0#k<4%d-Q]k)T]Y,_&db-pFf)+@1_'T9m?\qtUU+8P^^HcTo!B9I_$o%sAGS&?d7Qg84\
+7J7@2=;82OB)/K4h#F2+C1C?AHJWY)FtkgZ2"FJiGpr1#qn'<eOqldFVaI>1>ZSi,I&&t!4i$qk
+ehstg=$FBDb_htdOOm3MW%o)>?]+!N4>c&'n``kN!;)n//Jd@5Y28>cNRcJ6Bf3Y=-i?^=V1/=1
+s/>n$*r0Y'U4iPr,He/'MB1esle*CtIAhR&'p<_bOBb6U\c1;'cp)_I(9NaK]*0UK(_L"`:&[si
+76^2_=k(%AYPBfS11bjA/"3Ogb$FHBRSAmL3!iQ#Nb2dEV4ETS4!Tg@R74Ba(&YF]^0(M!>FM-`
+N-3pFl%RUNQ&"WWIsFoZf#?!4\i`ZogE#=Y+X4[ZjGU>AZe.EsRs_hL5%kFk$466t&/3tE!Y^YI
+F]QC_"=lPA28lX]D"C8hY<NhG=acc).fskJ4SFc\C&B\e9D'RZ^%<#feTUCU0/n35f(CZZE"sF:
+GIZppj%\3_2s"ZM,eHF_7rGpVGT&;P2sV.(j5d`78XJ/V?>"K$7`CmLCJ+,'d7pAbLQ+)-+UX:b
++/PP,QYN9Fi2R5W7Glhb'?ngM>-*BcfU8lTbAFu'q6nVgc!t'sbAH+s<B\1lPN2?@ZM/R>3-h47
+]?.M#Y2p+X_t)-2FS%eg:04AaSM!!U48WU$hj!$hgm1<&9[>e<[MO+!GF2IS#N\_NhOAEoWkuiJ
+kWp*hMd;fB'cK6CCi[LmC+6LFg/)ST^C5E88:mVC#a2!Q`?-R3.WKmhml(nH$)5u!Jg=/WXLWgk
+[0f,#HWekqZHb?Ai%R?4AE7l&?>U2,>NLGCNiE.VE,#sY"JVF^-*&+l<pFkh"CG0N:WbSHWieBm
+<Ul`jhbFnbD;KB;Or#]Od1HV.X3TLinnW4mhDY1Q@\^\)):@OJIhh_T0!C`'^<"o\QdtMA<;E6j
+b?/+GL/Ok;gZjn_r3Xe/QhaZ.Y,3rtX6Ad9]CO,l?U%5/cAth;AB=9`+hAP$d8&nZpq=dnFg7q#
+Sb(%&6a?(j5]#'YV+miiUPMeCD,oB!_nT"qXL`XQ5?/HNA=JQ58e9]TI(mdIGLIE7.&2eC)YV;F
+VCXWN,<h@RG)Rd^Zsd6=O_MRGs-crs])("_J&q'hou'lKUHL]E<@7[aID%)QBnB//U/T;&&%d^(
+2RJuuH(dlg.CQ7D_W3.XLAdEd=$/T'%XsP?:canSUu-+>O#d8"RB*"1Vk7J8/S2[W03,\_CNc`-
+3h%S5/+<I:UtYfW%)4i0Y"GnTPdXIkRq>mS;rUH2n&2TjM!&Q]$Oa;]mE&%F#K3FOg_T=7=X6?3
+q'U5WC!S0nKT_(R)F!.<r)YQX<UD.C_Q*C7m(>Z@<3?`DYBr:[ge^a'1QpM0(Wr_#KlX1WTq#l<
+M7du%<MEsl'Y!VD&?LVg"&FM[FWl@5g@$:h<XU*R.fW7qA`_i,G&59Uf#F"jZYO&dYZ&d*jVXAe
+Xh[\`AJLVC[T&10c\;e,PD3YV'q,Ss;^]DennL3)>?/qn`n!MT%*M9g0H44$SHR.$,0+LD^f#g<
+">6]81+]J!VSh,.A9M'Z=.D#s0/4Ha7Seh.>:5ptCj7cLD8gH,X?VQ[$*66PHh(nQ^ogF.Qb81U
+W9NR*Rl[<G;_fmEY'[]8lg'FHRAO:pp/t+&2V4g/"dI<Ei\?[<gd6'aN3YXh@Fho.Pk?C[Ep%p1
+,?OqJ3R%G&_3r7[J283%3R"P"!7Ra/44>G[J18nr^gq'mS@OP.^q=4n?j7eYG=(6q0UZ#HQklcT
+PNB=VA9_!k'/ipBA8N'OgrgETmofn9TN2)6+XoZW,Is#1FM+S[6+Ud6-O%FI<fYH6<fT_jaru*K
+3G&eb,PJ?^FCqat8/W[s;?i=P`ZR9P%$E[iUR,K-+?:bW;S[rO$;SHG,@J5."XdY2!)+1u!S3lD
+mUQ\PGEN,nUPdF@SQ+"[B:+8b0N4&7AdVGO9L0"\VI2;CM5$=uH(l*BRS_`@dKGaYQ>"GfWrrfn
+@4*U*bNTIS#P+mI^_![X7Wae$*`5Z>r3"g"6oQ,P7"-'c+Z]o<,I2Z?#SE@oDFAZ_%O!l)&gO^Z
+F46DlN(S-3W$I.W8ohkK4>P^!$>7:q;#qbI,'G3:gJUrl\OjE*,NS4-*$K=6/Rip_*#:i'-b5H%
+7i('pctO*,Il"J<B*FHnX>$jaQB?'C,54Zb^ec*2,N<7n*0K-fR#^B*4Q@#^no9^-c,G5q;>"89
+H&CZ::Dl1:;au`:<.@ru>6AIg4_^sI;O3TcCh4>h2k8s5)fF`H)btG+%4=1&L6EU?[T,R\CupJ/
+XkZLdHiV+',f`&XP!_jL$F$tH$Lf`c'd-"M"aClm$F%)f"^'Sa3BR[R"aCfk$BW3-!^$jS![]4o
+!%V<T!(k0[^^A[C^pC7FJ7i:gJ7i;R_d6W9R\p9sPtQ.B(+)'0\<-hT%$MYPL5d0N7c1IT&[tI!
+cBc?S"u-KUR+@Zga)W`dP9U6%6WO4Hj[]CfKHu<V+j&[TgW8msS)j@#9a^ZO9a\BX7gf$M9a\-&
++uqhs)hj]G*%Bg3*%Bg3*%Bg3>fn.E`<nC+D,S.SD,S.SD,S.SD,S/$3E!XE3MV+/E[cA%f-.%n
+",M[5BkXh[CF_>#K]RrCVXj^,"Ok_AS?Rcqg]ADJ)?Fl:%<"OjLpsVD&/(9JP/21V0j&<A#0RIn
+@(B\_li<as#XB)Vjb@6Kgb9/&)hPnH__9%t!ZV7nN+!klN+!kX-PDljR0DNqB+YPF3@</XY18J:
+]7@"$dFF1Bi/29H5]elY&A+6^.n$O_i<k=BAeYYZbpZ,Lc^DYm`?n9M69g4;2s=B9OS8sa*7:%:
+45#D2&c)((*OWQr7shG!XH7Z"i%UOn6JcheZ#)%2[+`"nLrD?j['_fdm#X0Zn>]p>$[J(U"oqP-
+a?+4YQc7?V@hXF;a:[4@1lD@E1ZZ5+/4\K0jcC0DhALrd8;^H..*p&,7*"@`Sf;teoX-6%P6h$t
+gcRP9!VEWJJs.V9#Yps2NSs5/=Tg+7Z4WThb2c;9mH%(YmDVg5[J%'?g>I1b,^P0j2PP%%Du)X@
+>q$g7Q\S'aO2/OcGVa=:>,0VDJc:Op[kM`<ZE'c+/sF@"dRR@AE3A$)+hBS#F.u(:ONI#9;\sHZ
+YX6P$*F1X3cIqP/2u1MMe@jZ'[+UMq!)_GP`3THa^#mXebsu(J:c&>(RKDQITQATGJaA%"dV[[f
+^1psHc[n/a:0"),X0&"KrRN&QqL&gEOB_78`!I[a?=/5AZ0gRV-dO"/g@s^^/C&_Cbmf-5i<7F8
+T7WPZf\^+_d$d)$r7hb\*L7Z6J`RPa\kdacj`*8;S?n8om-cX`?us6+f_-*$kn1+^oZ6Gn2thI6
+\A@<N?VYp>DNer+1JPp@]d`=&oaJcUgCT%-0a+aUPCtuDm;,98O\D(h+'A(t?S<cLAB?A.[q#US
+o'c`(OZ0`0?28&8?d0Ku0Xr8.N)+PLraYpB7$@AeHr%YXmqG%(Z=0[pGj=$R:N(?1Os"UYo_lLT
+/cjiWW85S26N,l*UbAl\2_RA20`<P?0J^i]G2+^e@Wm$7epE9[l>SG_$\1CV/qZ#o(Yre\G)^ES
+qifR#Gg/K?l_ZV_LF2k8rd%2<WIrA+f+HXK6Hro_\M!"$fJl(BPtAX4\FE6!nYr*9J27tp^74TV
+`(U1V5AjVX=ZG9;KUAE-T+c1h_N9Q1EBpo[3Ya=V`rnY`:USOL:8?.#',ND]8]5P^RUY,[lp#K1
+h.4b2Ibk2U9&Fa,R-)G`U_ePG'_S((c_\TrB5lmPbfd9K=3?0Aq:O_j3CXo0Wk$&7r)u#<I)"PQ
+GM2A<?J8YlNpj`MoPl$8,H!1T!;dV&p81u%k-aI/onN.lp"o=\a1:LFamnm'k$T[hAcRWKV?SRQ
+WV1/LSFiTOI<iL?(Fh'.WYY>?qqZleX)jul:p8#9qt;Xh5Q-@-<W%YF/c#u]I;l(Kj79o8f=,>!
+b=/\hlr<&R0`&s\\!s+@Cu_b4(]13\X.oEes';!F&9Y$";aQI)e8)Jaf4mV;qb2L>Lq`\hO@_96
+HEDBoAD:"s3rek*heQ3j-&4e.d<[IM,u[la"B9>RO8>oqe0XHL6t,lFD4Ob#oC^>ANC$\C3)5/L
+o'ZBJg;Eb#.'M9sGdV9\m4TMs'JFjuY?q)(f>ZaX&KJ+FFIgb1AgiNWLI\dqhh?Bq<gk&#244lS
+V%9O+CLuQ3p(M'cGkjr/IAR2]0?!Ze78&B;%XVB%R/F-ss(]>eX9gTDB((PFA^&rrFCpo-.>?UP
+e4-=_B;kG-mad$,l,oU\7`3!k?V[j<ll:@]ra=Zb6a\R_4/??Vd;\gVEc3U<%<cj.2WsD6I]IrL
+[Z8$t]6GH.!B?$VY/LfoJ(PK[`BN$1+RL%2Bf17IO_8PQF7EI74;@W:2HST"0)IF@Dp%Jm&5Hl+
+Y5f\XOY;1.[anlQMtjHtX)664HJ'rI%Ai9"+B9iC`o#!\1(TE^e2$2HP30esRI'r`cZq8G~>
+endstream
+endobj
+6 0 obj
+5077
+endobj
+7 0 obj
+<</Type /Font
+/Name /F0
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#43#6F#70#70#65#72#70#6C#61#74#65#47#6F#74#68#69#63#4C#69#67#68#74#2C#42#6F#6C#64
+/FirstChar 24
+/LastChar 255
+/Widths 8 0 R
+/FontDescriptor 9 0 R
+>>
+endobj
+8 0 obj
+[321 321 321 321 321 321 321 321 321 375 
+589 857 804 964 804 321 375 375 482 857 
+321 268 321 804 804 804 804 804 804 804 
+804 804 804 804 321 321 589 857 589 589 
+911 804 857 911 911 804 804 911 911 321 
+643 804 750 964 911 964 804 964 857 804 
+750 857 804 1125 750 696 696 375 804 375 
+589 589 589 696 696 750 750 643 643 750 
+750 321 536 696 643 857 750 804 643 804 
+696 696 643 696 643 964 643 589 589 375 
+589 375 750 321 804 0 321 804 536 911 
+643 643 589 1393 804 375 1125 0 321 0 
+0 321 321 536 536 750 857 643 589 1018 
+696 375 911 0 321 696 321 375 804 804 
+750 804 589 696 589 964 589 589 589 268 
+964 589 536 857 536 536 589 482 696 321 
+589 536 589 589 1232 1232 1232 589 804 804 
+804 804 804 804 1071 911 804 804 804 804 
+321 321 321 321 911 911 964 964 964 964 
+964 857 964 857 857 857 857 696 750 1339 
+696 696 696 696 696 696 911 750 643 643 
+643 643 321 321 321 321 750 750 804 804 
+804 804 804 857 804 696 696 696 696 589 
+643 589 ]
+endobj
+9 0 obj
+<<
+/Type /FontDescriptor
+/FontName /#43#6F#70#70#65#72#70#6C#61#74#65#47#6F#74#68#69#63#4C#69#67#68#74#2C#42#6F#6C#64
+/Ascent 911
+/CapHeight 804
+/Descent -214
+/Flags 32
+/FontBBox [-100 -250 1279 872]
+/ItalicAngle 0
+/StemV 0
+/AvgWidth 643
+/MaxWidth 1393
+>>
+endobj
+10 0 obj
+<</Type /Font
+/Name /F1
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#48#65#6C#76#65#74#69#63#61
+>>
+endobj
+11 0 obj
+<</Type /Font
+/Name /F2
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#43#6F#70#70#65#72#70#6C#61#74#65#47#6F#74#68#69#63#4C#69#67#68#74
+/FirstChar 24
+/LastChar 255
+/Widths 12 0 R
+/FontDescriptor 13 0 R
+>>
+endobj
+12 0 obj
+[225 225 225 225 225 225 225 225 225 300 
+525 750 675 900 750 225 300 300 375 750 
+300 225 300 675 675 675 675 675 675 675 
+675 675 675 675 300 300 525 750 525 525 
+825 750 750 825 825 675 675 825 825 300 
+600 750 675 900 825 900 675 900 750 750 
+675 750 675 1050 675 600 600 300 675 300 
+525 525 525 600 600 675 675 600 600 675 
+675 225 450 600 525 750 675 750 600 750 
+600 600 525 675 600 900 525 525 525 300 
+525 300 675 225 675 0 300 675 450 825 
+600 600 525 1275 750 300 1050 0 225 0 
+0 300 300 450 450 675 750 600 525 900 
+600 300 825 0 225 600 225 300 675 675 
+675 675 525 600 525 900 525 525 525 225 
+900 525 450 750 450 450 525 450 600 300 
+525 450 525 525 1125 1125 1125 525 750 750 
+750 750 750 750 975 825 675 675 675 675 
+300 300 300 300 825 825 900 900 900 900 
+900 750 900 750 750 750 750 600 675 1200 
+600 600 600 600 600 600 825 675 600 600 
+600 600 225 225 225 225 675 675 750 750 
+750 750 750 750 750 675 675 675 675 525 
+525 525 ]
+endobj
+13 0 obj
+<<
+/Type /FontDescriptor
+/FontName /#43#6F#70#70#65#72#70#6C#61#74#65#47#6F#74#68#69#63#4C#69#67#68#74
+/Ascent 825
+/CapHeight 750
+/Descent -225
+/Flags 32
+/FontBBox [-100 -250 1279 872]
+/ItalicAngle 0
+/StemV 0
+/AvgWidth 600
+/MaxWidth 1275
+>>
+endobj
+14 0 obj
+<</Type /Font
+/Name /F3
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#41#72#69#61#6C#2C#42#6F#6C#64
+/FirstChar 24
+/LastChar 255
+/Widths 15 0 R
+/FontDescriptor 16 0 R
+>>
+endobj
+15 0 obj
+[750 750 750 750 750 750 750 750 300 300 
+450 525 525 750 675 225 300 300 375 600 
+300 300 300 300 525 525 525 525 525 525 
+525 525 525 525 300 300 600 600 600 600 
+975 675 675 675 675 600 600 750 675 300 
+525 675 600 825 675 750 675 750 675 675 
+600 675 675 975 675 600 525 300 300 300 
+600 525 300 600 600 525 600 600 300 600 
+600 300 300 525 300 900 600 600 600 600 
+375 450 300 600 525 825 600 525 525 375 
+225 375 600 750 525 0 300 525 525 975 
+525 525 300 900 675 300 1050 0 525 0 
+0 300 300 525 525 375 525 975 300 975 
+450 300 900 0 525 600 300 300 525 525 
+525 525 225 525 300 750 375 525 600 300 
+750 525 375 525 300 300 300 525 525 300 
+300 300 375 525 825 825 825 600 675 675 
+675 675 675 675 975 675 600 600 600 600 
+300 300 300 300 675 675 750 750 750 750 
+750 600 750 675 675 675 675 600 675 600 
+600 600 600 600 600 600 900 525 600 600 
+600 600 300 300 300 300 600 600 600 600 
+600 600 600 525 600 600 600 600 600 525 
+600 525 ]
+endobj
+16 0 obj
+<<
+/Type /FontDescriptor
+/FontName /#41#72#69#61#6C#2C#42#6F#6C#64
+/Ascent 975
+/CapHeight 750
+/Descent -225
+/Flags 32
+/FontBBox [-664 -324 2000 1005]
+/ItalicAngle 0
+/StemV 0
+/AvgWidth 525
+/MaxWidth 1050
+>>
+endobj
+17 0 obj
+<</Type /Font
+/Name /F4
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#41#72#69#61#6C
+/FirstChar 24
+/LastChar 255
+/Widths 18 0 R
+/FontDescriptor 19 0 R
+>>
+endobj
+18 0 obj
+[750 750 750 750 750 750 750 750 300 225 
+375 525 525 900 675 150 300 300 375 600 
+300 300 300 300 525 525 525 525 525 525 
+525 525 525 525 300 300 600 600 600 525 
+975 675 675 675 675 675 600 750 675 225 
+450 675 525 825 675 750 675 750 675 675 
+525 675 675 975 525 675 525 300 300 300 
+375 525 300 525 525 525 525 525 225 525 
+525 225 225 525 225 825 525 525 525 525 
+300 525 300 525 375 675 525 525 525 300 
+225 300 600 750 525 0 225 525 300 975 
+525 525 300 1050 675 300 975 0 525 0 
+0 225 225 300 300 375 525 975 300 975 
+525 300 900 0 525 675 300 225 525 525 
+525 525 225 525 300 750 300 525 600 300 
+750 525 375 525 300 300 300 525 525 300 
+300 300 375 525 825 825 825 600 675 675 
+675 675 675 675 975 675 675 675 675 675 
+225 225 225 225 675 675 750 750 750 750 
+750 600 750 675 675 675 675 675 675 675 
+525 525 525 525 525 525 900 525 525 525 
+525 525 225 225 225 225 525 525 525 525 
+525 525 525 525 525 525 525 525 525 525 
+525 525 ]
+endobj
+19 0 obj
+<<
+/Type /FontDescriptor
+/FontName /#41#72#69#61#6C
+/Ascent 975
+/CapHeight 750
+/Descent -225
+/Flags 32
+/FontBBox [-664 -324 2000 1005]
+/ItalicAngle 0
+/StemV 0
+/AvgWidth 450
+/MaxWidth 1050
+>>
+endobj
+20 0 obj
+<</Type /Font
+/Name /F5
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#48#65#6C#76#65#74#69#63#61#2D#42#6F#6C#64
+>>
+endobj
+21 0 obj
+<<
+/Type /XObject
+/Subtype /Image
+/Name /im1
+/Width 108
+/Height 108
+/BitsPerComponent 8
+/ColorSpace [/Indexed /DeviceRGB 255 22 0 R]
+/Filter [/ASCII85Decode /FlateDecode] 
+/Length 23 0 R
+>>
+stream
+Gatm>$Y/0UP*TY%aGGc6R"rJ.=J4:lE%r.`bW(s4@s47-^2.ies*r9oabGn1b]Ic%SH`RCIB'<N
+*g.]-LP46^PVU9#\r?/$)reK'(uW3f?@rOliDXd438HZXb79.OCH)RY..iNE(J\t27OLoKn!_4t
+G.Z4ge7"SeUut.)OH;m/I_R?0rBen4dS;j>l$s1tm,3hBQ3*B("K]>kZd2,$:6M8Z?EZkSB0DkH
++jg_*$A.?ofr*$W\=3Vl:65TKP^)8JHB\c/Vg[7cF?@>75-:3Z]BuD`,Y?RP@Ru6hHJV>:H($!a
+3'B:ST47<o%+n#U!dWIlB4mIuk&D2:S[PE_G&g(G"\-O(cu+%.%?/r9?p[J3]s-B'`oHU.pnHS.
+#K,t"Af"$cg1nI.j.MsenC/=9E15VQ74$'**UF(>9K5KF:r_nJ"A]KQ4<dY#8jKXEa_2#kY2S)u
+qCK=[Jadaomg!T>7iPZ#Gct4'oSEH**KRX)s/ZoXp&V!bCHS36LZk3Noe]Ka3f`6'"h#5dkh'&M
+k=t",4?==B"5;rn7d8,H"3-!Uk52q\'=LArI3b4I"Z^A^1TW+1GI7't'sG#s6-"h4[fa^ZB>Z;+
+bsoL/I:1<Ng6G\aC&PNcHs"%iZ,l-<]GIYhl_9-./^OmS"t2FcZ6:W^N5p9qMD(.cPiJfa/>u(O
+S,qR&gqG/;%@bD?nXN(BE1BmhlaHn[m)+Q7?4RrMa/u'`,d<BAEU`\1o@Y1herZ+iY97rMe+%g/
+kY0%Q3-K\pR1T8`UU8,YVa`:fR<G'f>lJL!o!`12rj%VsH1R50ZZi%P1<YB7Zi?F6?)Pr3$@U\)
+?g]V?nooDbkl#`*:=>3\@*&#t_#[1L2K0.L[hprTQKQ;]3:2Rp*?&METq"T$O8;#2MOd;K2]Vg)
+UD%p5TKMf&]A:SW6N+NCjqAg$G?:>+d"]`3mqem!*DeTcgjAHK>\NMB:3$da/naMOjNc`.ogS(#
+$coi4Md?oVpn13mrlX>H\;pI3*=U#:ju>C<^(A053N%fB4C<pqTWGq?PgH<kc`O@-hSs!d03qZP
+%DF4T!UkCfYcEIE.5\eHj4&m/6A&a=k>CAW^HTcl`aS0&;]sDe>8/ga+$PhEXU3\SWVcSi2n*aM
+D*!r1DFEdf_nLm8q?bZ")WC;nq.FaLTkr!$XSg"mZ^BtJ(c>fsGPB3=^-hSl_qjDrBOlP+o,d$_
+ooOf(mIo&r]MLD9.29)C-WkiCSQt'iTD7I*rd+<U]Jle0]I\7fm(=aF;oaNfrpCZ]?'DV$1M.HI
+S;34OS6]5BXTuPbZ5ndiK'h]81d<YO5^Rf)PS<cKemT:kc9h\?J)<+.GO6\TB"PpjR%;:'W-AR[
+Z=A];LKcO_HQ1h5>qPE3dQQb4X<$@%$VohcX*@YZLc*t=F[pe&2YjS(>%*s6dbCb9=KaM^R9=sV
+_A?d_8l783iVWBAJ3PaAlQ*Kb<dO]N#5*.KBi^"S2F`/b<\^&hB8W6]oASc*b?_L,SM,!qhEdlX
+>l(?O3;[ZeeVh"@.U^[D/>h%@j;dh2RF+GYT4!hY+3*frc8^o\o%1ds+-u6qa49P&*E^rZEpsc%
+``,d&H:(58E4'aNJtg*<V[Y[4"GS#XIA$31oa(WT2q-WO]0e5hYqV-51"8OTc8HAV<3>0cXLg0a
+*Y*L.kOe6TM?l>E;a&oEm5:11VkqfaLal'l%2Q/=a[`Ffhu.4"6B^P4=Ej!MK=#kTmPNgdUb.mb
+q<@%[!<6>'R^Y"'f"#RO%H73KabbO?b^cHL]R(3A>t=hVk]01JZ2SdM&rMl0^kp^V04Z:).kF@j
+rI4eA,`8>>6*:G_-[dL,;PN9HCHs0u&S5Mbd8apk8?p1k`Bu0-G4<t(/HL=3gi8sG03;bC:a7ik
+'gi+K9sJnE&/qP!>X[g!c,2Z'EZIUu*"H_f/g;U06p1c`oEA3JbPC)>QU(t.WQ)Te:/"5NC-l<b
+XJ1ZC;Xq4S,_CF>\l6I!hnGaKLJba7rVGns(l$q^jl+gpptpsI#F)+HO?&t@Pk(ak3.qE;D/pgZ
+B(LTed29O6W(-Tt&2:hHqt_%(n-m$bYEq1l4#Yco5RUCWOW,b$SJ@O>[KRLT'GcKLi\q);:WS(?
+Td+Li@t:DO>UOu81*aWN1Vi"PMm;?SVk8E)!q-cBeUXK%UZmnoiLMH<2ukje=pnktbEeAR,iWI@
+@P:0:3)[oG28]0eKYinTGmA>k/_6p)*@"ZG:7e%(5lb7k_5)ONW"GPi`(s1(&\KNGVpnXf<575J
+bqfQ_(':_a$F"P-U"YU`JUG[U7[Z+&D[#mpG7o:k9^H"CLNp*qega@Nf3:/mi9(!5+I=bt2uL7T
+'3;h"4!=_@brF4B&5,dTW5"q^3!$$kO%+X[_1T8o<7KR:@M+,.7]>lg_Qe2GC;Q$k'Ns'FPcF-+
+$`4;sas"Qc3MKu-=CI2@ot7C18(LLM8j'>M!qeBQ/sa]<(=1=Q9>!'2p]Q@;d^TFcQVCS+3n\ZY
+$lYPh-tsg5(ftMcZ$:&W2]kOjmD\X>q>@mM?7ZlC\%Tj`8]]@Y7\t[9U<7:6o0+)AbRCp(^f4Fi
+TM'1))X.Bc5aS9U$&j<@``,7c`aAg<Ml!8se#8Wr$)E=$0EiMc'rH4^f)78([)4d)k+M37e#4(4
+<2\_@nZ!IQ./<0FJCaJ1/JCpqLj=iVr=Z18R"M[Y[IkS\JOi)3b[OGW,,nXP=]1=1BN3p"'k-SS
+#Wdl4B*h);[nH4RNJpJ028jKUgDL(S!(oKlXPMu#Q<76WL6Fl..4%1N[iMe[/tXJ",-5rRB8J`9
+=cC-r#Z/1^??j&uMBKpcJi$bW3$8W7k5o]u<n8X21Z;=BSA6gIYrl7o@3FQ$@W=Z0+:&PJ=.D]*
+.^67K:_%f^J>M&a`@:H35]62)O@Lu0!kKq`G&B4P\?ugI3$(2AQ4Q>T^'(<MBRnfk(2C,qbjdB`
+,ilMX'RsG\Q5"R\[T>rB+;c4>Cjp>UpW@X8A:m2sT`Q1`PI7@NmB=^8gg\eHNKEo].$I5sDq-'J
+Ab2dUEi&h+JY70l0tOl^MOrPA'(O0m_P\d=>71tjnBF\+QH,t?1(lm1ALo[='dTfg]cg7T<^n+!
+K;$GQX\sJ*g(KM\3hp#BZ!er<#0ijb3E9udpJQ#6dA2>Egq?1keJf%&M^.D"3`S!>/),X[pAd;/
+)\Ko[7HcVq)g9TBmkPY(p(:O7g5c_-EsX60i!Vu$_")o\hamu?\+Y(gV\dgD.W"AuW+X>ITf5f!
+8qK#d4:G'E+HBG%<(rGnV2bN5W.!=FPZ>+u8u0+6f(of`Y]Mn=b(RQRJ7>1f9taWI3\^<(H7Y<a
+M1%;4bsm5;:VZC.f.,BlB`onO(c-4W[45aohFL8J)df&-iHtg&:gqIf==FG4![,tp2-C<e"&K!K
+74bJUW9$rs<='\64HY`IRprXQb!i)7RuFqkJj@[P;$mIA,&Q7a*JC`Ll#c8*6lZu)X._IEG:Jk>
+&6V7Se;HQoTOd+)/f'5h2/SLUXk3tPUK/8OOAP41+#Pm"jp*.RC50?hV*8,ceLqBHOc(LfUR(@l
+!$)JZ1GAlIkhJ^;GVAt,W3?M,P"3k8k0LPGHRoWue1Akga"<PfkpN08,M"*(Db53Dng_VkqG\a3
+H$*^/Nn`>dLg`]^J_m4+0E&Y"@[.'_Jd+<FV%dt0\F^A+"'-9tiXO>K@c>L'jf/G<f1/m$L<I^(
+OVjL+5>S,/G+(m6X'IepOJLftb^^Wp"<3Yg?%Oq59a"u-rZql$ieL:2fn_O1)M5B$-ds8%L/)'V
+E;"pTRr.RcAr$Un6Q7-4FQB^\7MnV^3cG\)S%RZh=bO6g/bh#qF9NA3d@'QZ<%OBg;MVmXmqL<#
+!Z7.].\R]D3pc)<$t?1LS-GPN.7*Ns-HT1oO0[%:YDXG8,g=&A^d+=hc1M(WP.UF\am;Xq'H:Q#
+"9!4kZ0&I;MIms^>Q*TKOmG%(I5udSe\\UVZ53'Vn,]C,>hL!nnogO:k<fPj>!RBCI24_$85`s8
+%+[$GfL]EkpZ9js@0+_o-d?7O<3W())'d&&6!J+98mXQjOKdVU_;_DXimMR2Od=E$dj.ZlL=u)r
+_SKpdkn"FP\EgL42D4Vu4*Gc@BX&P0A&qHTbX41G?-LOE@)bn:PX-7Th/G1>Cm8)J-]!H]SYSG_
+T,%u@%;[dZhG4/&KNZIRS>`7K*YCXqS+=)B**cq`a-7!Z4pI3^4,c;B6lRDj3kV%jZpu8A;Wn>.
+e)_44PVnrXmICgE]os=!_+Qj%+(@S1AJ_*MfWUhsLUA4_S06tq"5^;1'NKN,m<NMHY2+KJrjDM)
+/>"?lWFJMEqMB*VFbue@YbRgbVcCV?oi#X>4qJ&Y6X'bn%fT3,X36<^S8q:+aPXrgG\na-X4q3g
+c#0q.?L(1%:oQIg)I(dE@O6e)#=aE!14l;]:Iaq*=VN!op7*TuHoj.+#3^%L,n8r`]@\O8gF>$B
+!If-o/=?$r_90u[?]#F.ZG:YeH$O\P^`id?QSH>E2Ns2`%0d;+a,sN(5%b+o>>KJJs#`K9?HFtG
+<^&@Y\L)G;/iG^3aW@2XTg1=;k9Vj;*U;^!cYW9@%i8r/;dFT&lu+Z;#P>l1Ln,?4_=3/tH,8SL
+IY]E^.0^+gX]ia"E,EdPao:`(*`H4cloPsWQ-<VTP$>[eg8]9^Krb;blK5UcOD,t&<3.X1WZ3Bf
+T@%*U/1WO<cYs75#\Yb(+m[$s@OVm&6l?`).1>N_9n^bHn;8>_>hkh!Abo[sEW\"W/;"]Rl2l.*
+n-<QV(QpPb/n_U&pMs$1T0e.O#5TKg)%--8T8g^V]u1'^]#uu8d$\FW=s/^L$_M/^#ceZ+`,K,g
+0#Q75$hs,1Ik*^]AkR>N#oo:&X;.n=Lheed&JO')+48;k@o83Wnp1&KcaB__$X*p>QM/;kWA\\D
+OL'32130>LE9F0c^9Nl#C'b@'O('9&,Ldrofgo95OPuM&.m0EXho+H1#D2YHBbru1LPNC?qOde&
+O##>G*23XZ[&K9Z/kN+:8+o5JV+P=&PPTX3Ig7AY<n/E2?LOOBBKNI;Ph+@(3qoiKdLW$3Y\'nZ
+Cl'*7RTcT><\C`QO10U2*0&eei(QrJ5q:SjGH/@UjO'^<)?['Q5X/lPR-e6Z/cHCjrfp</A)2`_
+W0lUt9-B84pA_I'.TGMZLPGM9^]&L'_8R,heN\N@^lrTGQX<2K&pL@aItU-/*WLXrrrtM1j(88k~>
+endstream
+endobj
+23 0 obj
+5313
+endobj
+24 0 obj
+<<
+/Type /XObject
+/Subtype /Image
+/Name /im2
+/Width 225
+/Height 225
+/BitsPerComponent 8
+/ColorSpace [/Indexed /DeviceRGB 255 25 0 R]
+/Filter [/ASCII85Decode /FlateDecode] 
+/Length 26 0 R
+>>
+stream
+Gb"/l%<J6t&;EaXILl\!(dq@&s1c3_!k,L*M;i*ajI+D`S"&:)2T]QTo)_c'#Qt3[5TgUD"9O->
++:ne]!eHCt#gqPca7\Of%]+i_R"<P.$=kt;a^Rid5gBp5,.^mYPM7@R)bO#>k*taT--hQ&hf2te
+9^/<.<(Q4n00&-MKYRT5:gg`aE%-'TUnEaZ^7NH>`2kr0.(ElS^k/*&#^6)OP\`9J@""cUg'0Wi
+oM>i=:oot(R\=#A`mU+TEEZe7c"R<[hY5/4ZjH]Mlgp)-)1bq>iB9fo-(0l^4[[CV_AIjpR^p/6
+Bqaq.?\%:N.U?E0F?jH('O:4tM"T0n/b)&qW\qj-)h,im3hO9UOC]Sa."kU19<"qBB-@hdUgF26
+=JSbmbWm9o$d#7?+V=WPSS:LS:u9ZCIlDnN:oJc=,gdS7Ah(Y'_1/dqA@!]OisOAm*t%,`n'04d
+?7>\\m.uRm0V>BQkb=1f4q7t]e^EV/b1,oLA@Wd%5FA7Ga$WCs)Sk_9=*QGm:jqWak9.ZE7#n=a
+q5KS,MpHB4NF:G\6%M)(egGt5-FJVAVtr]8dCXgLG(#o7UWTD'o&g50cVaJ<:#l(2XapTnNf[og
+2oFpp32t/a&F*&qd>_I_/uqJEfX#IP?V*16<@j!LD9`++6@VgMj2e9s]0H7(M]ElaO;GKTiQm6S
+\coLSk`+N25d=%?N_,h8"fb?sn:<@S*aL^M,S3-b9C$M%_C%]Q[6>nmqFYJUG#pnub'^J9rE4]u
+ku:`RD9$ID2cdIQNhKdd&[fF8nm'`>+l&C_ph(_f`2@(W3Z.0g::gtT"+__,a3&"K6EFJ%r=>Yn
+"iPFC-FA.,<!mjKph/(ZKcJ*I#R-P`P5-h"<@lXK(oo%l'"*5/LEN@Td!FL@pGG7qX#a/6;3ZT<
+&ggc\W/Q3+G5i!82R6ljlS*8tf_mV%gW$BH]B+5=]77hRGnq2s>Jq&+\G\31d44`hje;FpkVALd
+K<=t^!ce*MoE^c-M\1^(pWmNnh=+Rj(k&pm1Z4%&n,4rKaS!*e8b(&*@f.o5mLe7lMUe#SIRh?]
+M;$tGD."_fqe%[Aem8tJ^[)Zc!kC:g858E"pgIK<T/3!QOHk/Fh?u&a&B-]Hl(?'-E_N8-WBad[
+Z3]K);`<]lYn75^Fc#HE:#?\J]fC8nQ/_A\Qm1sl+3#($rgD%BA(Tsn!':,gfO:NLqJQ5DJ^6PJ
+Bgg:bI[F1>iptEG+(d[h!$_']=<9mn=,>'bUX,+C**&%'MgpJ(DMk]J(gHR`EB_k-pc-t<@nX/(
+O]-h?S&Ino@;MpPC#i6e[3*DSh3g<(f[VfhZld:'fp#8#D5,%3`l@maCtUD-b?hmm1=X;SA'Nl0
+In"YVBPc^aYl[O)22"^`$5LTWT,9R5:p'$uoOhDLh!5&<90\B+6HEe5dd9FGU`&^qSMoF4G/iV)
+U_0^-9D[SLJSC3?90.e,?QbjbacAj9%c(T0S95BW7*_*I(gDEm]l'dLA4D:"r5/Tp96LAB9Mp-6
+8/^r'TWDqob2WZ?fVK'5iZkulf?(qL?0_Q@V(#A97c4LcJq`UMY^P.G=nc7(&*O[net#"<dq=I4
+6do!.Ar<qDr\&*\bN:VG36Zd'`6MT^=ZaHfkC>`n*Jq[[cie5QpN:[CP7+Ic>&lQR[(?Y&Yb/QB
+lic_h[p>o'F2=b6S,XX,C0qcN:B[Rha^p(1l[+>c(;-M*KlJ[T%!WF%:$/p-3AW3m"C:^r3.tJ.
+1k$;V![G>S5Xl(8<3]SSmM3V7mV+WQ)QZ]ii#r[,VG6\Y<.sN9D<F0*SN_EF^^JYM/r`,h&Bo\;
+KDqe`@Z(,'"6OG'gKtKi.dk8$AYD^_pFUuZl_/X(Uj6%n:SD`ma63YhCpiMVs)/!"$mL7uMZp"n
+.Y6<qKh#R$@qp:VkTmc"`CMnCN\2V)m:D_4\1SAM"%]>/Wg*-@;2sHBj-P%>NqP]I9I[+^g;>,C
+.,Ge-o7O?)*M.O?KUF4`^?K@g?.%LF!iCW^ot!97+`@u[.)l!;!tsi^n6>8M:*2rZOO*-micXO%
+g#$M#;4rC&a]m'<9AA&g#R)]#.aGE)h`qJA7l'SDUQkM,I'I@:LZ50ZqOgVdf=DLjK#V*a`Ij_s
+)l*Vjp[dK)ePG&A%`sX\:4--C9(G8UPetm[m.G3*8FIMq"aS))/Q<2nq=-?b&i'81U(FUfLOo4(
+W[kFu66RX4.@LJC+mJF@Rmt=7Tl5lq,J'0')/>b>f=jI*k/i*f;q[]1O5(1]^=\Kb5Y2g.`:[,7
+!23`N9k+?Y+3&rhi<uTRQJ6EEZp:lcrM5rFb`uf-B&irlXKFV\YW_WG2e<T40?,Go]-3a%!+H<l
+c_6@/e[U!2n6Lsi%qEcgrsUMEN%JQ;1T:4*[QO6/T_$(Ro'ER^T-)(=-iOuoIMc9Yq.DDW@;HhC
+T>BTDZ"9/L#*U.K(>WE@:7FQLN625BS'KoD)?7q[JU^-q0_o-n@A`[FjI`DJq-e(o#LP@Lp<Q97
+IMc:^JHR/%rA+NQ0HNU*M^O8X1HY*DGe!eHoOmQDrgBYUj6Zu%oETdH.B,9=0<;lqY_Y0ok9tX@
+N%N8DCYoFdm"_i7"e,)[_`re/%q>uU,YEO\B<_8ACgf/pLV!a)C-RY/Yhcec+(5km+3"rl-r#-5
+r>2F20Xafc$L_<]j+e_rQAssRT*a@.m"JrfMItIYpZ<LDY-2JY9&g-lI'ZOq32s?apWlgQpgIui
+I"k;QNuuB1"Ssp[C%XjVju7s$-EXhWPDm^aTJ;XfQ"biqE/HDi#d*g"lg+<_0IbJgBmq$!%Hu-&
+R%D#S0fnQj@;NJ_G5(gOQ5b/FAf*XK(kFK7U(fZaEu#Su"9O->+:ne]!eETZ&-rC?JcEYQa&Jgr
+~>
+endstream
+endobj
+26 0 obj
+2928
+endobj
+27 0 obj
+<<
+/Type /XObject
+/Subtype /Image
+/Name /im3
+/Width 225
+/Height 225
+/BitsPerComponent 8
+/ColorSpace [/Indexed /DeviceRGB 255 28 0 R]
+/Filter [/ASCII85Decode /FlateDecode] 
+/Length 29 0 R
+>>
+stream
+Gb"/l$a\P<&;C;J@Ua4'7SP`=s*n/eimD7s)Di=t%*qV^[PM8P]]HT6]T=9*GW[%.a5c]74<BR(
+j7.@V*mYgfJ2/I$KIi3L;.dF'P7pQ.;%tc0AP.N^Rkm3*+Gl:AU<nHa<%*N8Zq@Y^ebus>JT>/\
+79L?Z&HfJS.4@&B8^7&X&!arl.3r?7/NFWJSa+H'$>fFDi1(UghD/oVB/0aF)+SDT;Yi@;XC7As
+c6>%M%$"Jeo^R)>/S^IlH8(NK!&IGp@Wu">,q7=F_ku5q/WanV*F4an_PA$3+$0u/e247jE(L+>
+8VrT^k<fJp?5>7uQ9^aC<u=cUH$+!?-Eo^kTDjIM(&=R,ZLpNQ?YiJMR%'<PpG[K@,0n_WICuV=
+OK$L]I=[??A(pIb/qdStm>gB1^j0UTX!%;K5i*eK?+[>s^9<Z5DEI37=+TWqBbK-;g,-&/eF>a+
+QJ3Al6efl_SnM-o^BD]P4'[HSIf%KCfD/Ma4/]-7"?&:V7f4]Hd8NYR\+=)rkT&0TT*suq8!cTk
+#SLFK/tNH8GuN#D<<tb/G1l#G3XA=CIH7Or#W'AH/RA^9=m5E+_cU8f:WFiaXJ.l@[[[(ICtJer
+.dYTKm<3qP882Cp0*EbYmFHGBNJWC\NKH@#*G#2pV1I1JU&?1bb6DH"A4c4n(2EtKJ`ToO5]i"k
+*=+spo2TCqh<$KPETf)G[8a#K44ka1Gh[jVQ,#V@;n8+7e<?WfO&>VCLi(&b',[rP/&hnVmCn.6
+m0Xt2/rS+HcbB,\7@2$^beQJH$j%43#%_]h)7^/m'&la\M1EHT4(;m[1q)QO(/d)kCf&8#EG?\Z
+=#+^*Y.j+^/S2Qo._W%MdUX`E_4d;"Z]VL``@sbe\4o5]'4j)E_Z"hLq\P>oeD&?8jIQuq2]/k%
+h?<DTm\@RW>!=7ue!M9TV@WZ-;6G6-Lqk]Y`rt(>!gUV(8o0l)DH14Vaq$:WFP_Z+5;O9jdU[.%
+7Jq\l5=>'G(b=lhA<?`iG5mL:(cIZQMgWm*aSdp;O@Jf9P4j_rm/@m1`&ENMPl1T"s,=85kF\n2
+g]@E`#`M]%CTb35eG^>q2K3IsmQXEka?lFRiS3nU?[`j@0'qj:d4#5_JMK\VVWDI6k9*TUkaOIS
+8;j:J_JD]k6!jt`1$gr&Q[]PZmFr.qpcF%s(]-\XE^C"fc*F-XPc'nB9IlS3r%K3:KC/`7^g5NZ
+A:]44Eu:tb!Q.k#ek8&LiJ0,kR=Bsi)"!S1`Y;t_)<GN=O5C)nO5TTT&-tF*pgHi^kF[;n2bX][
+l,2\VJJm*Y?eQsQ"CguK5`i[ZVUtn;'OpXZ&5%.NnbsNT9HaK;N2[o=PZ9p&Ha:WKLC(us@8&,1
+"QC;G!gVY#J;\"!r%P!I=ftBYecZ1E+`4;&`Y>s$g,6"5(mGs6@8,pChWf[U:cBQXr@k*JE*-OK
++Qsd5LG>Z!f?CZg"$b!7W2h0:"NiPFLp@n?C#E@BC=!F(*E,1].@\Oj8.(:!rRK[`&;MO:-kK/6
+k?'lsjM;S=UIB`"PBCrJSl^=iD^qh?UF]e,"(rBO<n7V6N"U@8B/Y;B_EZG5p*ul&m,smj3kXi<
+p&rMmg(1&B0gi/SIk;J)`Dr-+5K1!T"N$T#b+;`VEi!`WNiZmX52HT:-nNE5c2$*]lPBUahV,W"
+%K\);Z[',X#qWPIHht+b+H"?[-AA0fXe&B<GC;`n[[JF>![-I0R*hstSeRUDRp!=!n90f/_[V[G
+9K`trfV^lqZhf,4fu_YQE6p+:(_d$cZp.5G$h\0]&litXIuHj"rggmi5CG#)k`0TfMF&F3nS,S`
+Zg6XlLIRWtm0f-c-Q])Kq!:,U(1^bp]Xh[!e`Ar`X:MPfRmX_.^4$[P""H\KI.a592H#EMU9La`
+g8t'5&?:QR=A5(sJp5tXX;aPDfT(Tq#pbCSh]US0YNTIQ(:EuQAcdOQ/4\3@!*iY6ZF$,k?^G5j
+JH>+il:sltBr;9KgJrmk/hb]N("?lng$MQu_m0FqY-"Dn6s2qo;,dV#KL(ifh[WNZkMlcEUKIqo
+T[GF7WX5p5faeXm"+Qe?LcSHfI:,U0*g)F+lfYI1^"3Jg.CVH&J;!N/Lhp%3q0\`1Bl9IQFZ,8"
+&lM3k>G>I1XKig7*UO.AT#1@ODsGcYMUCq<56Zbr2u^hO>\4H;TAEUcbB\uh$-gpGod@mTj2-R0
+d^J2umR&t:Y4qWb3t4_'@f%GDeQEOATm7peCVhH5"fsBp2u#mbcttD>\hk*iWW!np4J"_kWF+.B
+%h:"`6*k<c"U^A^6uOs8@JVmqR6\;2&Ya//iI:n_$7Iq6Pk)l)n`>.P/^P6*Pb2;4IQ]$(0<c,&
+g>a9D2],e%*e2^*FJ:kippZ#/OB#-=T,B.UkUR:KTSeP9I2O>+le>r3#<)>rn?JFZms`!uo1#D?
+lN=!qFg+BWfM]Epe_03k&5seG\KM`YlB)f0;',m6f?-T>`]o*u%qEa!rsU5=N%+4t$-<#uVS)TJ
+@.V:'o%$$Xc4=F->Q5*e5E%%dr%j`<0W'g"cX?=]R*n5',(enT\UVW!l24a(ol8IR/,r:g_W6J,
+7@dqo=8j*!LN.Hel47[OeG"ZH7QoVhY!AkbSF!5)7epKJeY`RCKhqY'm<N@9/WR#C_iL_pR8ZmX
+)1G8ijp+]\1RAZN+3#!-7+qU4=@DM20nfbhrkD>pAj;5'KJDuB4:"@ALG8s;0CdkrU@J+h9F2"7
+c^S8C;>Xd\JIf6_2ueg=IMbH%A`)&:<ES=2(dh9A-!9%h>N1AZ`Y=sW.R2.#k@C:\%C`g==uZ@5
+VSqu>A#DDM=ai#@('o9p#(0bB/89Y:.D-$3]!=At8!k+!8c1hF>f_`'b^/pnqXPC>rOjD[kp,>F
++3#"NB2[,W9\Ehi3(.h46KhtO*O2#pq)cdo(7u2.*N0'!]B'LH)fkO;oS!2(5^nXfgLf>0FF:N)
+Jbo8]M\\ikR+cG5a5c]74<BR(j7.@V*fnA%nT\=%*t2mk)ZTj<~>
+endstream
+endobj
+29 0 obj
+3055
+endobj
+22 0 obj
+<</Filter [/ASCII85Decode]
+/Length 30 0 R>>
+stream
+s8W,)ZEg-rUm@=4R@0ItL5*prbh_+2GB\7]J:QqMlBu6rR:\5h'GM`8,%"\a$k*P=9hcTI*1<4,
+bfg(eR5<'!1RVhT1G]$_f@L'*!mI&gAhsEI3B?-[j7N!96:+"NAi#jC1X)6eAnGZ!baE'T!**$!
+baE)CbQ'FT1RXX2Xf7E^R:^u"!6iZ!bfhmCbVL[s.5PQ9bVM&C1B<h!1M-UeJ,fR]R/gieB$?[2
+Ahu6eAnIITbbiPPbj>@AR5:8!bjX-&Aso&CAi%ZTs"cHCAnIGeAnEi2RK(KC!&FWT1Gf(2AhsDe
+V#VY=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz~>
+endstream
+endobj
+30 0 obj
+448
+endobj
+25 0 obj
+<</Filter [/ASCII85Decode]
+/Length 31 0 R>>
+stream
+r;?Kcp%@_>mH!?he^`3`]tKGdNi]=`4?P`3?!Y_"bl@_D*#or7Ci%n^gm+.i1c.$?/1ecZ`D''$
+$k*PlI!cVB'LY>WUnje3,UA(tKk+_)S=H*K<)dp[F1&E`zzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz~>
+endstream
+endobj
+31 0 obj
+296
+endobj
+28 0 obj
+<</Filter [/ASCII85Decode]
+/Length 32 0 R>>
+stream
+q"XXGjlQF<r9`n=h;-o:eC:V&Xd#'7KnY4T9hfG?Co!l&]tM*a>[/6g*%``o4Ztq.!!"8i,\:Ou
+$k*Q_`5KmDb`%L>77BY9SXhVq2&$`=<`W7LI=8N2[<6V7zzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz~>
+endstream
+endobj
+32 0 obj
+296
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources <</ProcSet [ /PDF /Text /ImageI ] /Font << /F0 7 0 R /F1 10 0 R /F2 11 0 R /F3 14 0 R /F4 17 0 R /F5 20 0 R >> /XObject << /im1 21 0 R /im2 24 0 R /im3 27 0 R >> >>
+/Contents 5 0 R
+/CropBox [0 0 612 792]
+>>
+endobj
+34 0 obj
+<</Length 35 0 R
+/Filter [/ASCII85Decode /FlateDecode]
+>>
+stream
+Gat=->>sQA(4N0=s.HB_g7kRb=RmaJDfgMaRUMWcG5G_$#KK\NDqe;^EldmflCYTL8Fe?h+hQ8n
+-ao)^jZ?P7\AWMli4ACYs1:\%:/='gS=WOm3cI(c6>$poQg<+aMd)NE+)ekE:J]9=nslm]?N)''
+Ypl^qjGq9+Q',psNb)5[ZMHsqrc<D&kg],h18^1_'c<Lt$F(`"nWLdo=%[J/OIR0a8a&PSO9`2K
+ZR<I&dW2r#ec$g+7:,c8I.O_J@2(_N7$<.,A-F:2K)BV7i]98lAZZ<<LQmb+7SuM.`[Kut_"DF*
+_P[u*p-#:,2;0k<AT#:G?ot?%>SPtVbjl/OqO;aM"o*3!2?:5l0Yb,/>t)E*9?AD3960^F7i!$A
+GYGM!/a"jh.Q-,)<B;=b=+gd:q)bAQZ_XQKq'GP[)[DR?*4`dZDWAJmGNdQD]^,C$'^bWqZ``m@
+V-(jL0X&kHE0sG@'BV0,2W4&^r"uWI2<p.R:El+tXi?/G1U!S.Xck-H1CZq6CM)L"0Mleq4?j6)
+3h?)<Gr+`>12XD/0@cL=<@1=ohC?fkA`]]NZ-@s,O`_d[*o]d_1*Tdg>V9InL)9'?fVAf\QX8+u
+'!<8tCtMjaQ>s#5?]`$TpLOC)jbo^#>?^;uqO6<l_]cPR6lQuk&0:#I_#_46>dpNQ70a_=]rm&F
+;6!@,-+R3lAP1#cD)2+VhiNO"/Nb<5Nn=V_'nh8L7G@'tHp7!KC8iB>*-Rj8!N(tgs-XFD<iu^_
+A?/Qp(a:,:!20gM\(:^#Y],1ol50sIHr0-]4&M,%OY9Oh(LF2RN2qs!C/5ca:@TXWAf;e1HTe#2
+KnuSGBg_h1hQHCi(WWLBI37>rM!%ZHDQg0'"*nDjYT"lS2bO(;M*/d/\npKqnp:/\n>RWXd`&^4
++K`#R]+=G8WN<94YF_e!?<tS\o4gC!GkE',o'4(Ubc?<JnEQ_&6.Bat/@_q"?DoK'8Pbblgij#@
+0Uf`!Jb^-ZLBqulKu!1&%"r$2FLcq5Ki+l)4[e-c;VJ'*A0$qPH2"q5E;jftIK,?5noXp0lhU@W
+m&SQ6`31Jd;GMZI#Um%tl&2>i26e_j,ZCM[Pereo6Cm5=Pp5`\kG/`$cA@Vj/tlZj9)))5ps'[N
+CY9e+SQ>7SV/)k33af64,O(F:GR(>BVnNho*M[Q2DdU6slNW=fItQ\cbUM+'Y>BLSSZ,^_$8[jn
+p)'(:2AKWJ>#`jB\,n3Bkt>J^DU(,'pcEG33ous_RK86q/W_VdDuoTUZ&VK8]M/F1IK$X#>ZD8Z
+!AQY]L>RO6"9JpXG">B^>",l&StjX$ju/NZQ8Ru<P*LqVM(?:nN]&WKd>Z":PfuZJ2H!tfpsIFB
+&XdQr_Hg%AT!`*)Ac17qR]-<\6T,FlT=<+Mhd9%k_]2NoWNh50\9@I+L.<MKh_`T0QV(<h,"sIc
+@U3c6B+*g_?TDI\R#$G7JppWFilu(#Q/r6e1TsFm-Rh`98*Jh$#KB6(Ii4oYLtVj(=RDM6lJ>D.
+7_t0F+tsZ>7ZAQcTnurnLYS4f^0,.<.rGMoE-;qJoEY0<YA5T&a7]%Jba[R\6j#0i!-Gd;pJJ&K
+<a/f$!ErK(?smKI)k7Kn#Vh_6Ibse64(neP^TJ+phGj_<Fe0i4!P(S7F?Nl?I5-7H!XGh,c0%e2
+K$LNKiN`hR(]e!54)I<*UHmVX1B;M0U@gE%#:/Vo"cibn$e19L,t*?F;htdb_^;d/$me#,\Wr5q
+UU`52+G6^OE';*o$DbLj/>XaO]nWW,\G;e5fRp9m)LaNi)Heb66MFm:\@_c]B7&Wn9i5N'Zm*[5
+/JdXa.:S^1Z&CD&'<%K?*49Y_XSI1%Pm24>,ubO`"qQ!5\l6C[TVu%1Ylr<3F=)sd9Zjed5trdY
+,6hY<\W)M_6AI[><%8&:CXfHY(pJ-a4V(X]o?jOED+1pml:<FudV6bf+L'MV[>Bm(4:(O#N)A/W
+'/nc6l?SEYs8NSA2\'(cW8*L0ha^)S>I'E$K-c6C-)(I?[+,m+qGD#TK!:4H;=._h:&HZS.cYp.
+P68)m%H'q$P$;'P5mhflR+JIYCe*6Rd.&L721r<LQ&.'S!ZSA8co0$+Xh^VSNE'_^!fGf"78r2B
+KKBX'`Sh!M+7=M1nUUq3O=R8DL+N[;2YRkI%*=K(D%!A`!"S7,\(2qU..d`bYSHLXKW9dfl5k7*
+e2gG@7',3&oV)W:>eMEmMqho&hgG^Xpp>J1ob7HfoqA&Mm(h:KT-$lU7NJ\h?j(g<SXG#:qeYsK
+Y@m.ne)c[W8!%p/5D$I^b6R,*)keD(4-k1;<2VSpQ7[Y(30S&Nd%"fR!]p!nk;^\::4+F:O2(u,
+m,7L/]Pca2cBIU&Fh'.Knr)W1UbJ%:n"47-I=8gaXV^:o*T+=!a(8::Fb$X'fHbWD'?d5D#;M>T
+QZ$$DSK?M6`flH]]O_*9<oU!U`!2_`Z1[FN<0F/KL\ou4Dk?5k1,V."RAoY"$Yh;+f:ZI1JIDUk
+$nHV*G#(9IDgTo"SYE^U!sB_N8de>=3:`0c*OG#JH8;6^4XRtrSB$`<3%p@tnp71<JVckd`-M;L
+F?N7$@!j)K7K'GC2SaHq\<qK61]W"V?p#7[j&2&jCY#`)Eg%-r+8!'83m34?(VW]/"^Ygtn,^^U
+a7(]i#D?O.hC?r+%Ep<Mr"(Qde-[X:a7(G(HY;q`hlZWF1t:N>2NKa:c0"O%S[t;hTX.IqT@sa=
+Prc9hZnnH02BF$L]<_k=Uc,h7.s5O+BEoK_<BNT_GIo`cPM0i\XOO#2LWhW&?nWGN*o9-h^;-`2
+Z<iOnF+gQ!T\JQfACp9i6eAEYS)6X)3/Jra5^+[B`VHi(.s,<9o6ki:Qaa<_-bnU6!MQiAPC+b(
+8\4"dWTIHg#%YKcoY@-ZGX40XL5`fM+spo;fdbJRluS];--Y"C"oeKZ"NLou]k$SOs(A%V`W$+N
+'I6ER~>
+endstream
+endobj
+35 0 obj
+3010
+endobj
+36 0 obj
+<</Type /Font
+/Name /F6
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/BaseFont /#48#65#6C#76#65#74#69#63#61#2D#42#6F#6C#64#4F#62#6C#69#71#75#65
+>>
+endobj
+33 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources <</ProcSet [ /PDF /Text /ImageI ] /Font << /F0 7 0 R /F1 10 0 R /F2 11 0 R /F3 14 0 R /F5 20 0 R /F4 17 0 R /F6 36 0 R >> /XObject << /im1 21 0 R >> >>
+/Contents 34 0 R
+/CropBox [0 0 612 792]
+>>
+endobj
+38 0 obj
+<</Length 39 0 R
+/Filter [/ASCII85Decode /FlateDecode]
+>>
+stream
+Gat=,968iI'#)!#s.QLUihRcQ!2&i,Z'3;ZCh>heB6)YkJJKDeCPlLjb$+8;T5FWS_+9Zu;gq7_
+)Vnabd:aVLO%6pF+8F`Kk2H7)h;.lEj0=B#8JHMC%!OYnB5^$0^d<?m[m!$g\11/AYS#DA>g$F'
+4i9dPQ/)X^7%H3k<`Im*\GOVJ).uSqLge+t[1sQbI#p+=0A0OeY,euGD+ir_l''am;^@EM\JLl,
+/K;Up4[T#U.3i0kUV?s>CRh8.R)3SGDi63")[X9OTD;eaC)O,t((_d)UJ_Mf5:FL!(AT,3IJhRr
+(Lb+EYQ6o]II9Tf5dj6[j-/D`jLQm5TqCst)UW<Z%gMNaf_k+AD?C325(d':<H.UVhAF_?jTST"
+PapL&le;5Ao<<KB[o^?hcGL_p,Ap%2Z4`K81;8R-FHQE.#TpAP>&W'A\+U#701G\b6tSOL[ZM(p
+[aj,7'R;fo7Da[CdD>TBf_IFP&4WXW^jL`=pTFcIQ<\>U\$JKu3_i"[)+3UXoS!33%3#?6f4<Js
+G^Ik\oQ)]`,$Pdnd1rC0:;Wp1W&jj/40bnVPBFK,N8aK6Iq,#1$;CqUMn-uh/Hf`:`*f00Gk]o]
+DQ'=$H%-=h-m#,Si[3so_J:3Nl@J:h`ZL<P]U'NC:BKk8JL$2L\OaRsp!P"Z791"XX<RC?BY=@V
+>p66N3+3fU/qgP>$&<eL^^2]=dVotl+:Ps9_"ikBC#I1;Y05u1"@:+c&.o$WnMAK$"Iua-#WPk]
+37J3tU*955]-3Z&iH0U(,=C7<=Kkb5HC/=M()G-&#/d\2Z!<3a/(TEq<IdnLG%*nc_:Y_@eX?SB
+%',hK'a-"%c*Mu_3"nuR[Bh?gZg,k'Q7=467sR>iqY]s+a!=K]idHtSUGP%ONq#&-I0sXoP7/:R
+g%"Fk28l]\2$r0&QQ;$&?:,uQ?B[VoH.cWfju#Piju!I@Od@((DI.tm26Vl2/PjD:2KXbs/KN:,
+jlCet0bm,9_/_LB*"7)UYu;&J?_6DQ)h;GaW`?ib%oZK"R4`hK;,:p_B%C%^9NE%:;.XfdKm&-a
+rl77<_WP:?r;-7o1PIi^=PR`rFF+<E.3G67.KOZ:C3hF"dmAde[mf%Lh<6bkfugG\BVDBY+rBk]
+G$&'TcRn-8bjS1I62.\NjHbf1[BFJ*LJ;Dl!TlV[*J"nV<3h.9/9<+d4RP>ND6<-V1LOX\qK[%$
+[O26C4QLZ=f!<\j&UnSS%NQ.k\CreLqP/F=6?bn/>bH8#k^(aWXTu=H<b^kZ[([?p@%3jL:aeB.
+cAJLl7VDa]kO\lUrG;?odbZd/%o\8@,Q-JJ^[qK:r0FQD.aoN\K1W,kj)#i+rW_e7*TTZ$b*q+[
+0nJ8^1ENj-<3_$*3M;88();:>86o/nf0VBibgDB[+LA.(#)#90L>$AQAJJT\Dr_BqD-p\G?<aAM
+@hWrF*ZU>[8of%)Toc^8"Q)>NY\l-=pNSPlhGl8Okm**ZjLUF!Sfb]1\rcd6^[&JMV`kh!.aW?5
+;7F\_hfl#!X8<maSB+-i2\frXPKmX6ofalJ(IckeU<8:,<fU'[jL_jIIS",rnVU2F0Sm$bL3>c.
+SO:5D9np3h.nWLI>&eo2eiZj^/n=3(TR8t5lQBRVj+#\3GKMVh\=mb2CK23Ki=#a^L&,s"*V'KH
+'Y7JU?1s4hdLiIfA&Z;g+kLKXYiOsN^;MM]&3E9h-Yk+6R0UX7&_PI=(kePdaXnD;ZO%es-S3/\
+%oE@+JCGBp77@Ip&;q%pX5\]k<ifhsT.8otdKXjDC9=hu8p![9.H]7gob]1"a+4]6D5f6BgpI5;
+4iEhWGjnj9;Bp>blO4Mo-<@)7d#jXLkH7YWo`"!>5<e=FEJM`n`;95&gC&"_/@_e1XV$2"N3TVJ
+d"u5[mU#>)rkMBG^SI\Jcd@nqB0shkni',`LVWD'V;(d1Wl`9^g9$8$Wd><P_/p(s%J"HiFED1-
+0L"0E>uKRMiS&rr]X5-oNfFP67;S9M>UcnZi9K\%dpC<1(CG;S\X%L"J'kC;[u9t7X%Sds1WV.j
+k:j@r0SA.9ap`%.:+oGu;\4$-8XI#(;64k!R<t[=GV#7!`MWtS:1H:C!K1;-5l@=*FFCg%Rc\@!
+c.aS-HE4(uA1MI3Z$<sugog,d.s0ZN9$@I$gO8Y24j.BKIaEI/eUq^'c)G6]T^H<@4M,E`-crO-
+%Th$!!TO!ZW5g>ucd:]>:M5d>R%AP5;laF&#cb/HmQ`[0EfP2#rc3P`X2$36=MUmJ;P;D;!XngP
+.3'MZiu*c/m]Q5#!r:okr_G&fb`(nh>&6:e>,#!Wr?U<9AR-mK3917c_:#4fD'PXLSD46QKTgt]
+WM=d4W9;WiO\;cf2sts#H=C.3mkrQ((<877Fc?c'`oqF$$r$ABA8.$Kb\B?Y0iD;P6.8EkdGRTq
+dD7)^KpLA)3^P!pMXg3KTP5nK#]PN#Hg&n%?17/l1MnjU?#r6ZT]irD%'fMRL8>,aLV\o]lPf;]
+NZjdjXZahclp0nk__GUJ6_(mkTaa[3~>
+endstream
+endobj
+39 0 obj
+2573
+endobj
+37 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources <</ProcSet [ /PDF /Text /ImageI ] /Font << /F0 7 0 R /F1 10 0 R /F2 11 0 R /F3 14 0 R /F5 20 0 R /F4 17 0 R /F6 36 0 R >> /XObject << /im1 21 0 R >> >>
+/Contents 38 0 R
+/CropBox [0 0 612 792]
+>>
+endobj
+41 0 obj
+<</Length 42 0 R
+/Filter [/ASCII85Decode /FlateDecode]
+>>
+stream
+Gat=+8TWWE'Y\q6rrFo=eF?Wt!>8XXF6qP%dnUn+di=et+:=:a:kT0P<nq'>LP7"PLpifCQkY@3
+[kAgi'F'5F+hZ_N,.Tg"HM;B+KLlfl18RR(-KsFRpuqW:6o`a>*u;me-Poe%QRcB,ThDYmRj[h9
+B2u9)=+%nrZfZE%#!Mm4Hphop6j]=?bT$dU-eC]/d?H4BS@VOS/#C@MV,*9tbCH+kE_l-!7S(Se
+4fJ&bb-:$)s6Qr1kaH$b&8.qDU[rMcd?QthNfV%"en-qC.#p,1_7`\_iNP+qKU@KK:-s20JWi&;
+7TcQO#t#>'&cpaoV$XQfT&d1,[6[%1m>U>d2!c1n*q9"$2=VE<ndqQX?J"E#Oe4YcR-b2<_Mk"s
+Z>%g)/!m:mFE`9i,p_=lV8SM!7*XV`(m>8#ZUkqP0tLuS]Iu5T]sCSk8hk>S2=lHE-cJuh[696n
+%7lF).>^)Q46Q).q2R&;1[;nmI"K:Gmo((a`#dN=a/Oo<P/]eZTK&`n"n;^',tEklmFO7A>LKU6
+F#5S&c"'t]VA/\@A?78In@l#)_lCk,7BE)UhcX)@]Ol<&qs=4O01`^c;(b-r:R3Go2(4c*2n4!a
+hOXLt3,4nMUjA"42!Z[NL<5kWS6#'L0=K$PX!<\,*[Jia=197",K-e:,E+]I5(f>hdA#Q1<Rsh9
+]cJ>:HI0l?4$?'%NiQYSCt'!M+/Q4#H/$NskB2:'o5Pqq9XtZXdS'31H\d/E(&>KH?M/Pg5'hrb
+lPdgepPe9h`0?JQ-Xs2>UjD>CG><5aNpk`RG\Gtk;2A1f1*h]sP63)\.k;T[i%qB=r#JqDO/qKs
+&'a?W+$ZOtgZaLB065Ek8>jGW[V/LT2B7thD'W2o7ma14.urc_$)pBbS_[2"2-N:h<RCQsrcTO0
+jf1TSan`\VG2#%_*=8-maIPu4K-Q']<Hg3KqH8_H&DS`MoY1,('u#A$)rFB>k-8t@M+?>h;\G2#
+EW0;U4_RW-f,N7jU/a4/)?UR\_s<YrM^^L=\CE4W7^S(pr8ZL*DV2sDe-9j#iio`YK3jBmjb>8g
+4.s=e\q<1t[e7:;9)VR:kSWIoNiui#btUTf.dO8_EqOV%,aurqXtoXc\>m"r-Qq`)<i?UA`>b"B
+B>%W5K\LfMetlR?q)Lf8[db$;&Vd[PMagJhrOZ##E&@K%+o-qd;&&.;<Jhuj%Au/Xp'>hg#C>P9
+KC'csB1[GZYB-/3I4=:u9mNGEd[(X?jipoBGQkLYg^E3B&9kh4:)Y#i?8c\=m'mfKOlm$UU-D!F
+E%<tCcqcP9X<)0F"UjhE@gQbH[1E=TCJdm[9F3`.$,W)[X!^kGSCJVM@Oi7ri+g3,+#r01OtJ5X
+pjD;K\811nO_<#N,b+$nG?EXN%HO%C2?bX\L'kAk^:p*pJ7\o=g7S06?OA6)7%mC_'](B&0OUIs
+o^.!VZ8Z3^Du^5N#V@I3GDm+N6b`jB"&.?6kCXn<%M8k>&hEZ0aE+,lK"P/5j^SjbGZ]h5_1r[c
+L?Y41Ms4Omeq5Iuqd+)s;d-F.#R?s+@VreIGqr]Ec_8$#c[s*Sr$-;dBs33P7OVl+b=@2Z*8K<O
+3l^O1VG>XtFnSu\DXX:@n/aLl^'\T\:red3a5JRfH$,IG_7`8JkSY(7LK+[Y2_b("\7RO'g$uT4
+9YuU<Z*=Rr5-bjMc12`7TSdk`lNo?L[):R%UQLCAi(Xt3Ff15s<Boj#=<fZ$47G)PNPSnNVq.h!
+%<UcLF:_-b<YkW2;Uk;941D8lAA;&51tB)0*saCAgT^+rg&#[khe9!j66El@Hf4N\2UUHo~>
+endstream
+endobj
+42 0 obj
+1843
+endobj
+40 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources <</ProcSet [ /PDF /Text /ImageI ] /Font << /F0 7 0 R /F1 10 0 R /F2 11 0 R /F3 14 0 R /F5 20 0 R /F4 17 0 R /F6 36 0 R >> /XObject << /im1 21 0 R >> >>
+/Contents 41 0 R
+/CropBox [0 0 612 792]
+>>
+endobj
+2 0 obj
+<<
+/Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+/Type /Pages
+/Kids [ 
+4 0 R 33 0 R 37 0 R 40 0 R ]
+/Count 4
+>>
+endobj
+xref
+0 43
+0000000000 65535 f
+0000000010 00000 n
+0000034130 00000 n
+0000034185 00000 n
+0000025012 00000 n
+0000000210 00000 n
+0000005385 00000 n
+0000005408 00000 n
+0000005662 00000 n
+0000006656 00000 n
+0000006942 00000 n
+0000007075 00000 n
+0000007317 00000 n
+0000008310 00000 n
+0000008582 00000 n
+0000008788 00000 n
+0000009775 00000 n
+0000010012 00000 n
+0000010203 00000 n
+0000011190 00000 n
+0000011412 00000 n
+0000011560 00000 n
+0000023648 00000 n
+0000017113 00000 n
+0000017137 00000 n
+0000024204 00000 n
+0000020305 00000 n
+0000020329 00000 n
+0000024608 00000 n
+0000023624 00000 n
+0000024181 00000 n
+0000024585 00000 n
+0000024989 00000 n
+0000028611 00000 n
+0000025308 00000 n
+0000028418 00000 n
+0000028442 00000 n
+0000031593 00000 n
+0000028896 00000 n
+0000031569 00000 n
+0000033845 00000 n
+0000031878 00000 n
+0000033821 00000 n
+trailer
+<<
+/Size 43
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+34274
+%%EOF

--- a/tika/tests/test_tika.py
+++ b/tika/tests/test_tika.py
@@ -40,6 +40,10 @@ class CreateTest(unittest.TestCase):
         'parse remote jpg'
         self.assertTrue(tika.parser.from_file(
             'https://www.nasa.gov/sites/default/files/thumbnails/image/j2m-shareable.jpg'))
+    def test_local_binary(self):
+        "parse file binary"
+        file_obj = open("./files/rwservlet.pdf", "rb")
+        self.assertTrue(tika.parser.from_file(file_obj))
 
 
 if __name__ == '__main__':

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -140,6 +140,7 @@ from subprocess import Popen
 from subprocess import STDOUT
 from os import walk
 import logging
+import _io
 
 log_path = os.getenv('TIKA_LOG_PATH', tempfile.gettempdir())
 log_file = os.path.join(log_path, 'tika.log')
@@ -325,7 +326,7 @@ def parse1(option, urlOrPath, serverEndpoint=ServerEndpoint, verbose=Verbose, ti
     service = services.get(option, services['all'])
     if service == '/tika': responseMimeType = 'text/plain'
     headers.update({'Accept': responseMimeType, 'Content-Disposition': make_content_disposition_header(path)})
-    status, response = callServer('put', serverEndpoint, service, open(path, 'rb'),
+    status, response = callServer('put', serverEndpoint, service, urlOrPath if type(urlOrPath) is _io.BufferedReader else open(path, 'rb'),
                                   headers, verbose, tikaServerJar, config_path=config_path, rawResponse=rawResponse)
 
     if file_type == 'remote': os.unlink(path)
@@ -686,8 +687,12 @@ def getRemoteFile(urlOrPath, destPath):
     Fetches URL to local path or just returns absolute path.
     :param urlOrPath: resource locator, generally URL or path
     :param destPath: path to store the resource, usually a path on file system
-    :return: tuple having (path, 'local'/'remote')
+    :return: tuple having (path, 'local'/'remote'/'binary')
     '''
+    #update to handle binary stream input
+    if type(urlOrPath) is _io.BufferedReader:
+        return (urlOrPath.name, 'binary')
+    
     urlp = urlparse(urlOrPath)
     if urlp.scheme == '':
         return (os.path.abspath(urlOrPath), 'local')


### PR DESCRIPTION
I have a case where I need to be able to submit binary streams to the parser interface from_file function rather than file paths.