### PR TITLE
Remove closing on bytes

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -543,7 +543,6 @@ def callServer(verb, serverEndpoint, service, data, headers, verbose=Verbose, ti
     effectiveRequestOptions.update(requestOptions)
 
     resp = verbFn(serviceUrl, encodedData, **effectiveRequestOptions)
-    encodedData.close() # closes the file reading data
 
     if verbose:
         print(sys.stderr, "Request headers: ", headers)


### PR DESCRIPTION
The new 1.22 release completely breaks any calls to callServer for me, I propose this change to fix it. Seems I am not the only one, see #252. 

A few comments on the change itself :

Removed the closing of a non existing file (introduced at #229)

I thought about moving it after the read but didn't because the callServer call get's the reader from the parent. Therefore, the parent should be responsible for closing it. If the caller needs to have the file opened less time it should manage the read itself and after that call callServer with bytes directly in my opinion.