### PR TITLE
Add killServer() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 10. `TIKA_STARTUP_SLEEP` - number of seconds (`float`) to wait per check if Tika server is launched at runtime
 11. `TIKA_STARTUP_MAX_RETRY` - number of checks (`int`) to attempt for Tika server startup if launched at runtime
 12. `TIKA_JAVA_ARGS` - set java runtime arguments, e.g, `-Xmx4g`
+
 Testing it out
 ==============
 

--- a/tika/tests/test_tika.py
+++ b/tika/tests/test_tika.py
@@ -19,6 +19,7 @@
 import os
 import unittest
 import tika.parser
+import tika.tika
 
 
 class CreateTest(unittest.TestCase):
@@ -54,6 +55,12 @@ class CreateTest(unittest.TestCase):
         file = os.path.join(os.path.dirname(__file__), 'files', 'rwservlet.pdf')
         self.assertTrue(tika.parser.from_file(file))
 
+    def test_kill_server(self):
+        """parse some file then kills server"""
+        file = os.path.join(os.path.dirname(__file__), 'files', 'rwservlet.pdf')
+        with open(file, 'rb') as file_obj:
+            tika.parser.from_file(file_obj)
+        self.assertIsNone(tika.tika.killServer())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -687,6 +687,9 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
         return True
 
 def killServer():
+    '''
+    Kills the tika server started by the current execution instance
+    '''
     if(TikaServerProcess):
         os.killpg(os.getpgid(TikaServerProcess.pid), signal.SIGTERM)
         time.sleep(1)

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -190,7 +190,7 @@ EncodeUtf8 = 0
 csvOutput = 0
 
 # will be used later on to kill the process and free up ram
-TikaServerProcess = ""
+TikaServerProcess = False
 
 class TikaException(Exception):
     pass
@@ -664,7 +664,6 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
         return False
 
     # Run java with jar args
-    # need to check if shell=true is really needed
     global TikaServerProcess
     TikaServerProcess = Popen(cmd_string, stdout=logFile, stderr=STDOUT, shell=True, preexec_fn=os.setsid)
 
@@ -688,10 +687,11 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
         return True
 
 def killServer():
-    if(TikaServerProcess.pid > 1):
+    if(TikaServerProcess):
         os.killpg(os.getpgid(TikaServerProcess.pid), signal.SIGTERM)
+        time.sleep(1)
     else:
-        log.error("Invalid server PID, won't kill")
+        log.error("Server not running, or was already running before")
 
 def toFilename(url):
     '''


### PR DESCRIPTION
Allows us to kill the tika server and clean up some ram. Fixes #235

I still need to test if everything is working fine, so I'll leave this as a draft for now.

Another thing that I was thinking about was to automatically call this function when the program ends. I believe this could be achieved through [atexit](https://docs.python.org/3/library/atexit.html) ([source](https://stackoverflow.com/a/3850271/4542015)).