### PR TITLE
fix(parser): align `parser.from_file` with doc

### DIFF
--- a/tika/parser.py
+++ b/tika/parser.py
@@ -20,11 +20,15 @@ from .tika import parse1, callServer, ServerEndpoint
 import os
 import json
 
-def from_file(filename, service='all', serverEndpoint=ServerEndpoint, xmlContent=False, headers=None, config_path=None, requestOptions={}):
+def from_file(filename, serverEndpoint=ServerEndpoint, service='all', xmlContent=False, headers=None, config_path=None, requestOptions={}):
     '''
     Parses a file for metadata and content
     :param filename: path to file which needs to be parsed or binary file using open(path,'rb')
     :param serverEndpoint: Server endpoint url
+    :param service: service requested from the tika server
+                    Default is 'all', which results in recursive text content+metadata.
+                    'meta' returns only metadata
+                    'text' returns only content
     :param xmlContent: Whether or not XML content be requested.
                     Default is 'False', which results in text content.
     :param headers: Request headers to be sent to the tika reset server, should

--- a/tika/tests/test_from_file_service.py
+++ b/tika/tests/test_from_file_service.py
@@ -17,7 +17,12 @@
 #
 # python -m unittest tika.tests.test_from_file_service
 
+import sys
 import unittest
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 import tika.parser
 
 
@@ -30,6 +35,15 @@ class CreateTest(unittest.TestCase):
             'https://boe.es/boe/dias/2019/12/02/pdfs/BOE-A-2019-17288.pdf')
         self.assertEqual(result['metadata']['Content-Type'],'application/pdf')
         self.assertIn('AUTORIDADES Y PERSONAL',result['content'])
+    @mock.patch('tika.parser._parse')
+    @mock.patch('tika.parser.parse1')
+    def test_remote_endpoint(self, tika_call_mock, _):
+        result = tika.parser.from_file(
+            'filename', 'http://tika:9998/tika')
+
+        tika_call_mock.assert_called_with(
+            'all', 'filename', 'http://tika:9998/tika', headers=None, config_path=None,
+            requestOptions={})
     def test_default_service_explicit(self):
         'parse file using default service explicitly'
         result = tika.parser.from_file(


### PR DESCRIPTION
This PR resolves an issue where the documentation is not in accordance with the implementation of `parser.from_file`. 

## Changes

* Changed parameter order of `parser.from_file` to match documentation examples
* Added a unit-test to test the behaviour
* Added documentation for `service` to `parser.from_file`

## Addressed Issues

* Closes #273