### PR TITLE
fix(): pyyaml dropped support for python 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools
 requests
+pyyaml==5.2
 python-coveralls
 pytest-cov<2.6


### PR DESCRIPTION
## Proposed Change

The Travis build fails for Python 3.4 ([reference](https://travis-ci.org/chrismattmann/tika-python/jobs/636027154?utm_medium=notification&utm_source=github_status)) since the transitive dependency `pyyaml` from `python-coveralls` dropped support for EOL Python 3.4 in version `5.3` (released on Jan 6th).

```bash
PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8
The command "pip install -r requirements.txt" failed and exited with 1 during.
```

This pull request pins `pyyaml` to the last version supporting Python 3.4 (`pyyaml:5.2`).

> Also see: https://github.com/yaml/pyyaml/commit/039c9eb3082de06063fa669cf41a73dbeabb5d84