### PR TITLE
Fix TikaServerProcess

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -665,7 +665,10 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
 
     # Run java with jar args
     global TikaServerProcess
-    TikaServerProcess = Popen(cmd_string, stdout=logFile, stderr=STDOUT, shell=True, preexec_fn=os.setsid)
+    if Windows:
+        TikaServerProcess = Popen(cmd_string, stdout=logFile, stderr=STDOUT, shell=True, start_new_session=True)
+    else:    
+        TikaServerProcess = Popen(cmd_string, stdout=logFile, stderr=STDOUT, shell=True, preexec_fn=os.setsid)
 
     # Check logs and retry as configured
     try_count = 0


### PR DESCRIPTION
Checks for Windows on TikaServerProcess. If Windows, makes a different call.

os.setsid is only available in Unix:
https://stackoverflow.com/questions/38083168/attributeerror-module-os-has-no-attribute-setsid

Found an alternative command that seems compatible with Windows:
https://stackoverflow.com/questions/42257512/difference-between-subprocess-popen-preexec-fn-and-start-new-session-in-python