### PR TITLE
Revised patch from commit ea4ce60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+  - windows
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-os:
-  - linux
-  - osx
-  - windows
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Previous patch failed on another Windows machine, particularly in Python 2. Since TravisCI does not support Python in Windows yet (and the linux tests work fine), these errors slipped past the TravisCI. I manually ran the test .py files that the TravisCI runs using a Windows machine that has all 4 versions of Python specified in the .travis.yml (2.7, 3.4, 3.5, 3.7).

Based on the TravisCI logs of the linux tests, these are the files run from tika\tests:
test_tika.py
test_from_file_service.py
test_ssl_link.py

All 12 tests (4 versions, 3 each) ran OK, but this certainly could use more testing on Windows.