### PR TITLE
Fix ClassNotFoundException with spaces in TIKA_PATH

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -643,10 +643,10 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
     # setup command string
     cmd_string = ""
     if not config_path:
-        cmd_string = '%s %s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s &' \
+        cmd_string = '%s %s -cp \'%s\' org.apache.tika.server.TikaServerCli --port %s --host %s &' \
                      % (java_path, java_args, classpath, port, host)
     else:
-        cmd_string = '%s %s -cp %s org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
+        cmd_string = '%s %s -cp \'%s\' org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
                      % (java_path, java_args, classpath, port, host, config_path)
 
     # Check that we can write to log path


### PR DESCRIPTION
Tika fails to start when TIKA_PATH contains spaces. A common case would be applications storing the tika jar in `Application Support` on macOS – iscc-cli is an example for this:

https://github.com/iscc/iscc-cli/blob/ad466c3/iscc_cli/__init__.py#L8-L10

Tika server log will contain this (please excuse the german content, should be clear anyway):
Fehler: Hauptklasse Support.iscc-cli.tika-server.jar konnte nicht gefunden oder geladen werden
Ursache: java.lang.ClassNotFoundException: Support.iscc-cli.tika-server.jar

The TIKA_PATH set by iscc-cli: `/Users/strayer/Library/Application Support/iscc-cli`