### PR TITLE
Fix Windows breakage caused by #307

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -644,10 +644,10 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
     # setup command string
     cmd_string = ""
     if not config_path:
-        cmd_string = '%s %s -cp \'%s\' org.apache.tika.server.TikaServerCli --port %s --host %s &' \
+        cmd_string = '%s %s -cp "%s" org.apache.tika.server.TikaServerCli --port %s --host %s &' \
                      % (java_path, java_args, classpath, port, host)
     else:
-        cmd_string = '%s %s -cp \'%s\' org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
+        cmd_string = '%s %s -cp "%s" org.apache.tika.server.TikaServerCli --port %s --host %s --config %s &' \
                      % (java_path, java_args, classpath, port, host, config_path)
 
     # Check that we can write to log path


### PR DESCRIPTION
This is a followup to #307. I broke Windows with my change there, because single quotes can't be used in the command prompt as on Unix systems.

This is not ideal because `classpath` could be interpreted by the shell. Better would be to not run the command with `shell=True` at all and instead provide a list to `Popen` to let the subprocess module handle escaping of paths and such.