### PR TITLE
make tika CLI similar to parser.from_file

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -285,7 +285,8 @@ def parseAndSave(option, urlOrPaths, outDir=None, serverEndpoint=ServerEndpoint,
             log.info('Writing %s' % metaPath)
             with open(metaPath, 'w', encoding='utf-8') as f:
                 f.write(parse1(option, path, serverEndpoint, verbose, tikaServerJar, \
-                                    responseMimeType, services)[1] + u"\n")
+                                    responseMimeType, #services,
+                                    )[1] + u"\n")
         metaPaths.append(metaPath)
     return metaPaths
 


### PR DESCRIPTION
Thanks a lot for tika-python. its fast and awesome! 🥇 

I suggest the following change to make the command line tool
`$ tika-python parse all file.pdf`
behave more similarly to inline python function
`tika.parser.from_file("file.pdf", service='all')`

Currently, the command line tool produces content in XHTML by default, while the inline function produces plain text with an option to set argument `xmlContent=True` (False by default), which was unexpected. It is unclear how to specify plaintext output for the command line tool otherwise.

