### PR TITLE
[documentation] Add example with byte buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,15 @@ print(translate.from_file('/path/to/spanish', 'es', 'en'))
 Using a Buffer
 --------------
 Note you can also use a Parser and Detector
-.from_buffer(string) method to dynamically parser
-a string buffer in Python and/or detect its MIME
+.from_buffer(string|BufferedIOBase) method to dynamically parser
+a string or bytes buffer in Python and/or detect its MIME
 type. This is useful if you've already loaded
 the content into memory.
+```python
+string_parsed = parser.from_buffer('Good evening, Dave')
+byte_data: bytes = b'B\xc3\xa4ume'
+parsed = parser.from_buffer(io.BytesIO(byte_data))
+```
 
 Using Client Only Mode
 ----------------------


### PR DESCRIPTION
I wanted to use the library with a file that I get from another server, thus I already had the file in memory. It took me a while to understand how to hand it to tika without first having to write it to disk, party because there were no examples.

Counterintuitively, the `from_file` method does not work, since it relies on the `name` attribute of a [FileIO](https://docs.python.org/3/library/io.html#io.FileIO) object, which a file in memory (used with [BytesIO](https://docs.python.org/3/library/io.html#io.FileIO)) does not have. I don't think that the name is really necessary in the case of in-memory files, but that would be another issue to fix this.

The `from_buffer` method in always shown with strings and the parameter is always called "string" until it ends up in the `callServer` method where it is actually called data. Thus, byte data works, but that is not quite obvious. Therefore, I suggest to add this bit of documentation.