### PR TITLE
Fix unnecessary retries after successful startup

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -690,6 +690,7 @@ def startServer(tikaServerJar, java_path = TikaJava, java_args = TikaJavaArgs, s
             # check for INFO string to confirm listening endpoint
             if "Started Apache Tika server at" in tika_log_file_tmp.read():
                 is_started = True
+                break
             else:
                 log.warning("Failed to see startup log message; retrying...")
         time.sleep(TikaStartupSleep)


### PR DESCRIPTION
Even after Tika server is started, the while body will keep being executed until max retries is reached. It should break out of the loop upon successful startup.