### PR TITLE
fix(tika): Update download link due to broken URL

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -172,7 +172,7 @@ TikaFilesPath = tempfile.gettempdir()
 TikaServerLogFilePath = log_path
 TikaServerJar = os.getenv(
     'TIKA_SERVER_JAR',
-    "http://search.maven.org/remotecontent?filepath=org/apache/tika/tika-server-standard/"+TikaVersion+"/tika-server-standard-"+TikaVersion+".jar")
+    f"https://dlcdn.apache.org/tika/{TikaVersion}/tika-server-standard-{TikaVersion}.jar")
 ServerHost = "localhost"
 Port = "9998"
 ServerEndpoint = os.getenv(


### PR DESCRIPTION
The search.maven.org link is broken, so replacing it with the download link from the Apache Tika homepage - https://tika.apache.org/download.html