### PR TITLE
Implement test running using GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  tests-backend:
+    name: "Tests (${{ matrix.python-version }})"
+    # TODO: ubuntu-22.04 results in SSL negotation issues with test_from_file_service.py
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # TODO: 3.10 fails SSL negotation with test_from_file_service.py
+        python-version: ['3.7', '3.8', '3.9']
+      fail-fast: false
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python-version }}"
+      -
+        name: Install Python dependencies
+        run: |
+            pip3 install --requirement requirements.txt
+            pip install --editable .[all]
+      -
+        name: List installed Python dependencies
+        run: |
+          pip list
+      -
+        name: Tests
+        run: |
+            py.test --cov=tika


### PR DESCRIPTION
I'd like to start a few contributions to this library, and my first course of action is getting test feedback working again to help verify functionality (at least tested functionality) remains unbroken.

This pull request adds a simple workflow for running the existing tests using GitHub Actions.  For the moment, it does require a slightly older version of Ubuntu and doesn't work with Python 3.10.  Both of these results in a lot of SSL errors when tests attempt to retrieve a remote file.  I suspect the server hosting them is a little out of date, but it's not my expertise.