### PR TITLE
issue#413 potential solution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
     download_url='http://github.com/chrismattmann/tika-python',
     license='Apache License version 2 ("ALv2")',
     packages=find_packages(exclude=['ez_setup']),
+    namespace_packages=['tika'],
     include_package_data=True,
     zip_safe=True,
     test_suite='tika.tests',

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
     download_url='http://github.com/chrismattmann/tika-python',
     license='Apache License version 2 ("ALv2")',
     packages=find_packages(exclude=['ez_setup']),
-    namespace_packages=['tika'],
     include_package_data=True,
     zip_safe=True,
     test_suite='tika.tests',

--- a/tika/__init__.py
+++ b/tika/__init__.py
@@ -16,11 +16,8 @@
 
 __version__ = "3.1.0"
 
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
 
 def initVM():
     ''' back compat method for JCC based Tika'''


### PR DESCRIPTION
**What this PR does:**
A potential solution for [issue #413](https://github.com/chrismattmann/tika-python/issues/413).

The current use of `pkg_resources` raises a `DeprecationWarning` during import. `pkgutil` is recommended as a lightweight, standard-library alternative. Also, `pkg_resources` from `setuptools` has been deprecated, since implicit namespace packages were introduced in PEP 420.

This PR replaces the deprecated `pkg_resources.declare_namespace` with `pkgutil.extend_path` for namespace declaration in `tika/__init__.py`.

**Edited Files:**

- `tika/__init__.py`: Replaced `pkg_resources.declare_namespace(__name__)` with `pkgutil.extend_path(__path__, __name__)` and removed the fallback for `pkg_resources`.
- `setup.py`: Added `namespace_packages=['tika']`.

Updated on Apr 1, 2025:
Removed `namespace_packages=['tika']` from `setup.py`.
`setup.py` remains the same as the original version.

