### PR TITLE
Allow users to choose between md5 and sha1 for JAR checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,18 @@ These are read once, when tika/tika.py is initially loaded and used throughout a
 2. `TIKA_SERVER_JAR` - set to the full URL to the remote Tika server jar to download and cache.
 3. `TIKA_SERVER_ENDPOINT` - set to the host (local or remote) for the running Tika server jar.
 4. `TIKA_CLIENT_ONLY` - if set to True, then `TIKA_SERVER_JAR` is ignored, and relies on the value for `TIKA_SERVER_ENDPOINT` and treats Tika like a REST client.
-5. `TIKA_TRANSLATOR` - set to the fully qualified class name (defaults to Lingo24) for the Tika translator implementation.
-6. `TIKA_SERVER_CLASSPATH` - set to a string (delimited by ':' for each additional path) to prepend to the Tika server jar path.
-7. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
-8. `TIKA_PATH` - set to a directory with write permissions and the `tika_server.jar` file will be placed in this directory.
-9. `TIKA_JAVA` - set the Java runtime name, e.g., `java` or `java9`
-10. `TIKA_STARTUP_SLEEP` - number of seconds (`float`) to wait per check if Tika server is launched at runtime
-11. `TIKA_STARTUP_MAX_RETRY` - number of checks (`int`) to attempt for Tika server startup if launched at runtime
-12. `TIKA_JAVA_ARGS` - set java runtime arguments, e.g, `-Xmx4g`
-13. `TIKA_LOG_FILE` - set the filename for the log file. default: `tika.log`. if it is an empty string (`''`), no log file is created.
+3. `TIKA_JAR_HASH_ALGO` - set to `sha1` when running on FIPS-compliant systems; default value is `md5`.
+4. `TIKA_SERVER_ENDPOINT` - set to the host (local or remote) for the running Tika server jar.
+5. `TIKA_CLIENT_ONLY` - if set to True, then `TIKA_SERVER_JAR` is ignored, and relies on the value for `TIKA_SERVER_ENDPOINT` and treats Tika like a REST client.
+6. `TIKA_TRANSLATOR` - set to the fully qualified class name (defaults to Lingo24) for the Tika translator implementation.
+7. `TIKA_SERVER_CLASSPATH` - set to a string (delimited by ':' for each additional path) to prepend to the Tika server jar path.
+8. `TIKA_LOG_PATH` - set to a directory with write permissions and the `tika.log` and `tika-server.log` files will be placed in this directory.
+9. `TIKA_PATH` - set to a directory with write permissions and the `tika_server.jar` file will be placed in this directory.
+10. `TIKA_JAVA` - set the Java runtime name, e.g., `java` or `java9`
+11. `TIKA_STARTUP_SLEEP` - number of seconds (`float`) to wait per check if Tika server is launched at runtime
+12. `TIKA_STARTUP_MAX_RETRY` - number of checks (`int`) to attempt for Tika server startup if launched at runtime
+13. `TIKA_JAVA_ARGS` - set java runtime arguments, e.g, `-Xmx4g`
+14. `TIKA_LOG_FILE` - set the filename for the log file. default: `tika.log`. if it is an empty string (`''`), no log file is created.
 
 Testing it out
 ==============

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -173,6 +173,7 @@ TikaServerLogFilePath = log_path
 TikaServerJar = os.getenv(
     'TIKA_SERVER_JAR',
     "http://search.maven.org/remotecontent?filepath=org/apache/tika/tika-server-standard/"+TikaVersion+"/tika-server-standard-"+TikaVersion+".jar")
+TikaJarHashAlgo=os.getenv('TIKA_JAR_HASH_ALGO', 'md5')
 ServerHost = "localhost"
 Port = "9998"
 ServerEndpoint = os.getenv(
@@ -609,9 +610,11 @@ def checkJarSig(tikaServerJar, jarPath):
     :param jarPath:
     :return: ``True`` if the signature of the jar matches
     '''
-    if not os.path.isfile(jarPath + ".md5"):
-        getRemoteJar(tikaServerJar + ".md5", jarPath + ".md5")
-    m = hashlib.md5()
+    localChecksumPath = '.'.join([jarPath, TikaJarHashAlgo])
+    if not os.path.isfile(localChecksumPath):
+        remoteChecksum = '.'.join([tikaServerJar, TikaJarHashAlgo])
+        getRemoteJar(remoteChecksum, localChecksumPath)
+    m = hashlib.new(TikaJarHashAlgo)
     with open(jarPath, 'rb') as f:
         binContents = f.read()
         m.update(binContents)


### PR DESCRIPTION
Use TIKA_JAR_HASH_ALGO to specify algorithms for JAR verification
Default value is `md5`
Current valid values are `sha1` and `md5`.
SHA1 checksum verification is needed for running this library on FIPS-compliant systems.