### PR TITLE
Remove unused import and fix None singleton compare

### DIFF
--- a/tika/parser.py
+++ b/tika/parser.py
@@ -17,7 +17,6 @@
 #
 
 from .tika import parse1, callServer, ServerEndpoint
-import os
 import json
 
 def from_file(filename, serverEndpoint=ServerEndpoint, service='all', xmlContent=False, headers=None, config_path=None, requestOptions={}, raw_response=False):
@@ -86,7 +85,7 @@ def _parse(output, service='all'):
         return parsed
 
     parsed["status"] = output[0]
-    if output[1] == None or output[1] == "":
+    if output[1] is None or output[1] == "":
         return parsed
 
     if service == "text":

--- a/tika/tika.py
+++ b/tika/tika.py
@@ -219,7 +219,7 @@ def runCommand(cmd, option, urlOrPaths, port, outDir=None,
     :return: response for the command, usually a ``dict``
     '''
     # import pdb; pdb.set_trace()
-    if (cmd in 'parse' or cmd in 'detect') and (urlOrPaths == [] or urlOrPaths == None):
+    if (cmd in 'parse' or cmd in 'detect') and (urlOrPaths == [] or urlOrPaths is None):
         log.exception('No URLs/paths specified.')
         raise TikaException('No URLs/paths specified.')
     serverEndpoint = 'http://' + serverHost + ':' + port


### PR DESCRIPTION
This PR:
* Removes unused import of `os`
* compares to None singleton using `is` instead of `==` as recommended by [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)