### PR TITLE
Fixing the filepath used if the TIKA_JAR_HASH_ALGO env var is used

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -618,7 +618,7 @@ def checkJarSig(tikaServerJar, jarPath):
     with open(jarPath, 'rb') as f:
         binContents = f.read()
         m.update(binContents)
-        with open(jarPath + ".md5", "r") as em:
+        with open(f"{jarPath}.{TikaJarHashAlgo}", "r") as em:
             existingContents = em.read()
             return existingContents == m.hexdigest()
 


### PR DESCRIPTION
The TIKA_JAR_HASH_ALGO environment variable can be used to customize which hash algorithm is used for checksums of the Tika jarfile. It's primarily in use for FIPS systems on which using the default hash algorithm (MD5) will raise an exception.

If the user customizes this environment variable currently, it will raise a `FileNotFoundError`, as the hash file is currently hardcoded to be an `.md5` file, and not the filetype that's actually needed.

Fixes #438.