### PR TITLE
build(deps-dev): replace `python-coveralls` with `coveralls`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 requests
 pyyaml==5.4.1
-python-coveralls
-pytest-cov<2.6
+coveralls
+pytest-cov
 memory_profiler
 beautifulsoup4==4.13.3


### PR DESCRIPTION
This change was extracted from the work on #444.

The third-party [python-coveralls](https://pypi.org/project/python-coveralls) library is replaced with the more recent [coveralls](https://pypi.org/project/coveralls/). python-coveralls was not working anymore, coverage report upload to coveralls.io was not possible.

Also the obsolete constraint is removed from `pytest-cov<2.6`.