### PR TITLE
test: replace url in test_remote_html test case

### DIFF
--- a/tests/test_tika.py
+++ b/tests/test_tika.py
@@ -33,7 +33,7 @@ def test_remote_pdf():
 
 def test_remote_html():
     """parse remote HTML"""
-    assert tika.parser.from_file("http://neverssl.com/index.html")
+    assert tika.parser.from_file("http://nossl.sh")
 
 
 def test_remote_mp3():


### PR DESCRIPTION
I don't know why <http://neverssl.com/index.html> was used in the test case, but it failed a lot to access that site due to 

```
FAILED tests/test_tika.py::CreateTest::test_remote_html - RuntimeError: Failed to download http://neverssl.com/index.html: HTTPConnectionPool(host='neverssl.com', port=80): Max retries exceeded with url: /index.html (Caused by NewConnectionError("HTTPConnection(host='neverssl.com', port=80): Failed to establish a new connec...
````

If the reason was mainly to use that http / port 80, maybe switch to http://nossl.sh?