### PR TITLE
test: add tests for `tika.language`

### DIFF
--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from tika import language
+
+
+TEST_FILE_PATH = Path(__file__).parent / "files" / "rwservlet.pdf"
+
+
+def test_local_binary():
+    with open(TEST_FILE_PATH, "rb") as file_obj:
+        assert language.from_file(file_obj) == "en"
+
+
+def test_local_path():
+    assert language.from_file(str(TEST_FILE_PATH)) == "en"
+
+
+def test_local_buffer():
+    assert language.from_buffer("Good evening, David. How are you?") == "en"


### PR DESCRIPTION
This PR adds a couple of rudimentary tests for `tika.language`, which was not tested at all before. This should bump coverage a bit.