### PR TITLE
test: add tests for `tika.config`

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+from tika import config
+
+
+def test_get_parsers():
+    assert config.getParsers()
+
+
+def test_get_mime_types():
+    assert config.getMimeTypes()
+
+
+def test_get_detectors():
+    assert config.getDetectors()


### PR DESCRIPTION
This PR adds a couple of rudimentary tests for `tika.config`, which was not tested at all before. This should bump coverage a bit.