### PR TITLE
test: add tests for `tika.pdf`

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from tika import pdf
+
+
+TEST_FILE_PATH = Path(__file__).parent / "files" / "rwservlet.pdf"
+
+
+def test_local_path():
+    text_pages = pdf.text_from_pdf_pages(str(TEST_FILE_PATH))
+    assert isinstance(text_pages, list)


### PR DESCRIPTION
This PR adds a couple of rudimentary tests for `tika.pdf`, which was not tested at all before. This should bump coverage a bit.