### PR TITLE
chore: remove python shebang

### DIFF
--- a/tika/config.py
+++ b/tika/config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
I missed one.

See #449 and #466.