### PR TITLE
chore: remove obsolete import

### DIFF
--- a/tika/unpack.py
+++ b/tika/unpack.py
@@ -18,7 +18,6 @@ import csv
 import tarfile
 from contextlib import closing
 from io import BytesIO, TextIOWrapper
-from sys import version_info
 
 from .tika import ServerEndpoint, callServer, parse1
 


### PR DESCRIPTION
I missed one.

See #449 and #469.