### PR TITLE
chore: add spdx license identifier header to test modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from tika import config
 
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from tika import detector
 
 

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from tika import language
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from http import HTTPStatus
 
 from tika import parser

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from tika import pdf
 
 

--- a/tests/test_unpack.py
+++ b/tests/test_unpack.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from tika import unpack
 
 # Test data


### PR DESCRIPTION
This PR adds a spdx license identifier header to the test modules I created prior. This adds the license information, without being as verbose as the other modules. 

What do you think?

Ref: https://spdx.dev/learn/handling-license-info/