### PR TITLE
chore: add docs workflow badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml)
+[![Docs Status](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml)
 [![Coverage Status](https://coveralls.io/repos/github/chrismattmann/tika-python/badge.svg?branch=master)](https://coveralls.io/github/chrismattmann/tika-python?branch=master)
 
 tika-python


### PR DESCRIPTION
See #443

I will tackle #443 in tiny steps. This PR adds a workflow badge to the readme, to see at a glance if docs are passing.