### PR TITLE
ci: rename docs workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,10 +1,10 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Generate and deploy documentation
+name: Documentation
 
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "master", "add-automated-documentation"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
See https://github.com/chrismattmann/tika-python/issues/443

I will tackle https://github.com/chrismattmann/tika-python/issues/443 in tiny steps. This PR shortens the CI docs workflow name and removes branches, that are not found in this repo.