### PR TITLE
build(deps): add dependency-groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .[all]
+        python -m pip install . --group=tests
 
     - name: Run tests
       run: pytest -ra --cov

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          pip install sphinx furo myst-parser
+          python -m pip install --upgrade pip
+          python -m pip install . --group=docs
       - name: Sphinx APIDoc
         run: |
           sphinx-apidoc -f -o docs/source/ .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,16 @@ dependencies = [
   "requests",
 ]
 
-[project.optional-dependencies]
-all = [
-  "tika[tests]",
-]
+[dependency-groups]
 tests = [
   "memory-profiler",
   "pytest-benchmark",
   "pytest-cov",
+]
+docs = [
+  "furo>=2025.12.19",
+  "myst-parser>=5.0",
+  "sphinx>=9.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
See https://github.com/chrismattmann/tika-python/issues/443

I will tackle https://github.com/chrismattmann/tika-python/issues/443 in tiny steps. This PR replaces the optional dependencies with proper `dependency-groups`.

Ref: https://packaging.python.org/en/latest/specifications/dependency-groups/