### PR TITLE
chore: reorder .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,25 @@
-/.project
-/.pydevproject
-/tika.egg-info
-/build
-/dist
-*.log
-/.settings/
-/tika/*.pyc
-/tika/*/*.pyc
-.DS_Store
-/setup.cfg
+# IDE and project files
+.project
+.pydevproject
 .idea
+.settings/
+
+# Python build and distribution
+build/
+dist/
+*.pyc
 __pycache__/
+tika.egg-info
+
+# Logs and coverage
+*.log
 .coverage
+
+# macOS metadata
+.DS_Store
+
+# Configuration
+setup.cfg
+
+# Sphinx documentation
+docs/build/


### PR DESCRIPTION
This PR group and reorders the ignore patterns in .gitignore.

I combined
```
/tika/*.pyc
/tika/*/*.pyc
```
to
`*.pyc`

Also I added `docs/build/` which is the sphinx build.