### PR TITLE
ci: fix coveralls reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         flag-name: coverage-python-${{ matrix.python-version }}
         parallel: true
+        base-path: tika
 
   finish-coverage:
     needs: test
@@ -45,3 +46,4 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
+        base-path: tika


### PR DESCRIPTION
I just realized, that the reports on coveralls.io display:

```
Source Not Available

The file "pdf.py" isn't available on github. Either it's been removed, or the repo root directory needs to be updated.
```
See: https://coveralls.io/builds/79004134/source?filename=pdf.py

Based on https://docs.coveralls.io/common-issues-and-troubleshooting#issue-0-percent-coverage this parameter should probably fix that. Fingers crossed.
