### PR TITLE
chore: add more informational badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-[![Build Status](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml)
-[![Docs Status](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml)
-[![Coverage Status](https://coveralls.io/repos/github/chrismattmann/tika-python/badge.svg?branch=master)](https://coveralls.io/github/chrismattmann/tika-python?branch=master)
-
 tika-python
 ===========
+
+[![PyPI Downloads](https://static.pepy.tech/badge/tika)](https://pepy.tech/projects/tika)
+[![Latest release](https://img.shields.io/pypi/v/tika.svg?style=flat)](https://pypi.python.org/pypi/tika/)
+[![License](https://img.shields.io/github/license/chrismattmann/tika-python?style=flat)](https://github.com/chrismattmann/tika-python/blob/master/LICENSE.txt)
+
+[![Build Status](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/chrismattmann/tika-python/badge.svg?branch=master)](https://coveralls.io/github/chrismattmann/tika-python?branch=master)
+[![Docs Status](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml/badge.svg)](https://github.com/chrismattmann/tika-python/actions/workflows/documentation.yml)
+
 A Python port of the [Apache Tika](http://tika.apache.org/)
 library that makes Tika available using the
 [Tika REST Server](https://cwiki.apache.org/confluence/display/TIKA/TikaServer).


### PR DESCRIPTION
This PR adds more informational badges to the README, e.g.

- number of total downloads
- current version released on pypi
- license badge

See it rendered at: https://github.com/afuetterer/tika-python/blob/readme/README.md