### PR TITLE
chore: add ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
   - id: end-of-file-fixer
     exclude_types: [csv]
   - id: trailing-whitespace
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: 6fec9b7edb08fd9989088709d864a7826dc74e80  # frozen: v0.15.12
+  hooks:
+  - id: ruff-check
+    args: [--fix, --show-fixes, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,13 @@ run.source = [ "tika" ]
 run.branch = true
 report.skip_covered = true
 report.show_missing = true
+
+[tool.ruff]
+src = [ "tika", "tests" ]
+lint.select = [
+  "E4",   # pycodestyle
+  "E7",   # pycodestyle
+  "E9",   # pycodestyle
+  "F",    # pyflakes
+  "I",    # isort
+]


### PR DESCRIPTION
This PR sets up a first config for a ruff pre-commit hook including the default ruleset ["E4", "E7", "E9", "F"] and "I" (isort).

pre-commit is passing locally.

Ref: https://docs.astral.sh/ruff/configuration/